### PR TITLE
test: increase timeout value for testing

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -567,6 +567,7 @@ test('circuit halfOpen', t => {
       t.notOk(breaker.pendingClose, 'breaker should not be pending close');
     })
     .then(() => {
+      const timeout = options.resetTimeout * 1.3;
       setTimeout(() => {
         t.ok(breaker.halfOpen, 'breaker should be halfOpen');
         t.ok(breaker.pendingClose, 'breaker should be pending close');
@@ -595,9 +596,9 @@ test('circuit halfOpen', t => {
                   t.end();
                 })
                 .catch(t.fail);
-            }, options.resetTimeout * 1.1);
+            }, timeout);
           });
-      }, options.resetTimeout * 1.1);
+      }, timeout);
     });
 });
 


### PR DESCRIPTION
It seems like setting the function timeout value to 1.1 times
the circuit timeout is too narrow of a time slice. Bumping it to
1.3 times the circuit timeout seems to fix it.

Fixes: https://github.com/nodeshift/opossum/issues/239