### PR TITLE
bug: correct max failures check

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -525,7 +525,7 @@ function fail (circuit, err, args, latency) {
   if (stats.fires < circuit.volumeThreshold) return;
   const errorRate = stats.failures / stats.fires * 100;
   if (errorRate > circuit.options.errorThresholdPercentage ||
-    circuit.options.maxFailures >= stats.failures ||
+    stats.failures >= circuit.options.maxFailures ||
     circuit.halfOpen) {
     circuit.open();
   }


### PR DESCRIPTION
Regression introduced by https://github.com/nodeshift/opossum/commit/245d47b7bdaed73c6f79fd86df07005690a80486