### PR TITLE
fix: error message for open breaker does not have error code.

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -335,10 +335,13 @@ class CircuitBreaker extends EventEmitter {
        * Emitted when the circuit breaker is open and failing fast
        * @event CircuitBreaker#reject
        */
-      this.emit('reject', new Error('Breaker is open'));
+      const error = new Error('Breaker is open');
+      error.code = 'EOPENBREAKER';
 
-      return fallback(this, 'Breaker is open', args) ||
-        Promise.reject(new Error('Breaker is open'));
+      this.emit('reject', error);
+
+      return fallback(this, error, args) ||
+        Promise.reject(error);
     }
     this[PENDING_CLOSE] = false;
 


### PR DESCRIPTION
I create an Error with the existing message and add an error code to match the other type of errors. This also fixes issues with receiving only a string in fallbacks if the breaker is open.