### PR TITLE
chore: remove examples from greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -2,12 +2,6 @@
   "groups": {
     "default": {
       "packages": [
-        "examples/angular5/package.json",
-        "examples/hystrix/package.json",
-        "examples/jquery/package.json",
-        "examples/react/client/package.json",
-        "examples/react/package.json",
-        "examples/seneca/package.json",
         "package.json"
       ]
     }


### PR DESCRIPTION
fixes #275

As discussed in #275 we can remove the examples directory from the greenkeeper.json file so those package.json's are ignored.

