### PR TITLE
feat: add prometheusRegistry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,27 @@ app.use('/metrics', (req, res) => {
 });
 ```
 
+The `prometheusRegistry` option allows to provide a existing 
+[prom-client](https://github.com/siimon/prom-client) registry. 
+The metrics about the circuit will be added to the provided registry instead 
+of the global registry.
+The [default metrics](https://github.com/siimon/prom-client#default-metrics) 
+will not be added to the provided registry.
+
+```js
+const opossum = require('opossum');
+const { Registry } = require('prom-client');
+
+// Create a registry
+const prometheusRegistry = new Registry();
+
+// create a circuit
+const circuit = opossum(functionThatMightFail, {
+  usePrometheus: true,
+  prometheusRegistry
+});
+```
+
 #### Hystrix
 
 **NOTE: Hystrix metrics are deprecated**

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -186,7 +186,10 @@ class CircuitBreaker extends EventEmitter {
 
     // Add Prometheus metrics if not running in a web env
     if (PrometheusMetrics && options.usePrometheus) {
-      this[PROMETHEUS_METRICS] = new PrometheusMetrics(this);
+      this[PROMETHEUS_METRICS] = new PrometheusMetrics(
+        this,
+        options.prometheusRegistry
+      );
     }
   }
 

--- a/lib/prometheus-metrics.js
+++ b/lib/prometheus-metrics.js
@@ -14,19 +14,23 @@ function normalizePrefix(prefixName) {
 }
 
 class PrometheusMetrics {
-  constructor (circuit) {
+  constructor (circuit, registry) {
     this.circuit = circuit;
+    this._registry = registry || client.register
     this._client = client;
     this.counters = [];
     const prefix = normalizePrefix(this.circuit.name);
 
-    this.interval = this._client
-      .collectDefaultMetrics({ prefix, timeout: 5000 });
+    if (!registry) {
+      this.interval = this._client
+        .collectDefaultMetrics({ prefix, timeout: 5000 });
+    }
 
     for (let eventName of this.circuit.eventNames()) {
       const counter = new this._client.Counter({
         name: `${prefix}${eventName}`,
-        help: `A count of the ${circuit.name} circuit's ${eventName} event`
+        help: `A count of the ${circuit.name} circuit's ${eventName} event`,
+        registers: [this._registry]
       });
       this.circuit.on(eventName, _ => {
         counter.inc();
@@ -37,11 +41,11 @@ class PrometheusMetrics {
 
   clear () {
     clearInterval(this.interval);
-    this._client.register.clear();
+    this._registry.clear();
   }
 
   get metrics () {
-    return this._client.register.metrics();
+    return this._registry.metrics();
   }
 
   get client () {


### PR DESCRIPTION
At the moment it is only possible to add prometheus metrics to the global registry of [prom-client](https://github.com/siimon/prom-client).

This adds a `prometheusRegistry` option, that allows to provide a custom, non-global registry.
If a registry is being provided the default metrics will not be added to avoid having duplicate default metrics.