### PR TITLE
improvement: stop keeping a set of all circuits

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -20,7 +20,6 @@ const WARMING_UP = Symbol('warming-up');
 const VOLUME_THRESHOLD = Symbol('volume-threshold');
 const deprecation = `options.maxFailures is deprecated. \
 Please use options.errorThresholdPercentage`;
-const CIRCUITS = new Set();
 
 /**
  * Constructs a {@link CircuitBreaker}.
@@ -175,8 +174,6 @@ class CircuitBreaker extends EventEmitter {
     if (this.options.cache) {
       CACHE.set(this, undefined);
     }
-
-    CIRCUITS.add(this);
   }
 
   /**
@@ -226,7 +223,6 @@ class CircuitBreaker extends EventEmitter {
     this.removeAllListeners();
     this.status.shutdown();
     this[STATE] = SHUTDOWN;
-    CIRCUITS.delete(this);
     /**
      * Emitted when the circuit breaker has been shut down.
      * @event CircuitBreaker#shutdown
@@ -632,15 +628,4 @@ const nextName = () =>
     return v.toString(16);
   });
 
-/**
- * Gets a Set iterator of all active circuits. If a circuit
- * has been created, but subsequently shut down, it will not
- * be included in the Set iterator.
- * 
- * @returns {Iterator} an Iterator object containing a reference
- * to all {CircuitBreaker} instances that have been created.
- */
-CircuitBreaker.circuits = function circuits() {
-  return CIRCUITS.values();
-}
 module.exports = exports = CircuitBreaker;

--- a/test/circuit-shutdown-test.js
+++ b/test/circuit-shutdown-test.js
@@ -31,26 +31,3 @@ test('Circuit shuts down properly', t => {
       t.end();
     });
 });
-
-test('A list of non-shutdown circuits is maintained', t => {
-  function expectCount(iterator, count) {
-    // eslint-disable-next-line no-empty-pattern
-    for (let {} of iterator) count--;
-    return count === 0;
-  }
-
-  t.ok(expectCount(CircuitBreaker.circuits(), 0));
-
-  const c1 = new CircuitBreaker(passFail);
-  const c2 = new CircuitBreaker(passFail);
-
-  t.ok(expectCount(CircuitBreaker.circuits(), 2));
-
-  c2.shutdown();
-  t.ok(expectCount(CircuitBreaker.circuits(), 1));
-
-  c1.shutdown();
-  t.ok(expectCount(CircuitBreaker.circuits(), 0));
-
-  t.end();
-});


### PR DESCRIPTION
BREAKING CHANGE

This has been shown to cause memory leaks and can effectively
be implemented in user code.

Fixes: https://github.com/nodeshift/opossum/issues/363