### PR TITLE
chore: remove prom-client as a dependecy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,11 +2324,6 @@
       "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
       "dev": true
     },
-    "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
     "bluebird": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
@@ -9265,14 +9260,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "prom-client": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.3.0.tgz",
-      "integrity": "sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==",
-      "requires": {
-        "tdigest": "^0.1.1"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -11405,14 +11392,6 @@
             "path-parse": "^1.0.6"
           }
         }
-      }
-    },
-    "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "requires": {
-        "bintrees": "1.0.1"
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,5 @@
     "hystrix",
     "rate-limiting"
   ],
-  "dependencies": {
-    "prom-client": "^11.2.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
It looks like #350 didn't include removing the prom-client dependency

 