### PR TITLE
fix: circuit breaker global should be capital.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -20,7 +20,6 @@ configs.push({
     extensions: ['*', '.js']
   },
   plugins: [
-    new webpack.IgnorePlugin(/prom-client/),
     new webpack.DefinePlugin({
       'process.env': {
         WEB: JSON.stringify('web')
@@ -34,13 +33,13 @@ function generateConfig (name) {
   const config = {
     mode,
     entry: {
-      circuitBreaker: './index.js'
+      CircuitBreaker: './index.js'
     },
     output: {
       path: path.resolve(__dirname, '..', 'dist'),
       filename: `${name}.js`,
       sourceMapFilename: `${name}.map`,
-      library: 'circuitBreaker',
+      library: 'CircuitBreaker',
       libraryTarget: 'umd'
     },
     node: {
@@ -48,9 +47,8 @@ function generateConfig (name) {
       console: true
     },
     plugins: [
-      new webpack.IgnorePlugin(/prom-client/),
       new webpack.ProvidePlugin({
-        'circuitBreaker': 'opossum'
+        'CircuitBreaker': 'opossum'
       }),
       new webpack.DefinePlugin({
         'process.env': {


### PR DESCRIPTION
BREAKING CHANGE: since the circuit breaker is now a constructor, the web version should also be capitalized as CircuitBreaker. This is a breaking change since it is still lower case


@lance we really don't need to do this, since it is more a semantic thing,  but it would keep the usage consistent between browser and node