### PR TITLE
remove unneeded resolve()

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -476,8 +476,8 @@ class CircuitBreaker extends EventEmitter {
               const latency = Date.now() - latencyStartTime;
               this.semaphore.release();
               this.emit('timeout', error, latency, args);
-              resolve(handleError(
-                error, this, timeout, args, latency, resolve, reject));
+              handleError(
+                error, this, timeout, args, latency, resolve, reject);
             }, this.options.timeout);
         }
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -476,8 +476,7 @@ class CircuitBreaker extends EventEmitter {
               const latency = Date.now() - latencyStartTime;
               this.semaphore.release();
               this.emit('timeout', error, latency, args);
-              handleError(
-                error, this, timeout, args, latency, resolve, reject);
+              handleError(error, this, timeout, args, latency, resolve, reject);
             }, this.options.timeout);
         }
 


### PR DESCRIPTION
Looks like this is a mistake given `handleError` returns `undefined` and it will always call `resolve` or `reject` that is passed into it first anyway