### PR TITLE
feat: clear intervals on shutdown

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -4,7 +4,7 @@ const WINDOW = Symbol('window');
 const BUCKETS = Symbol('buckets');
 const TIMEOUT = Symbol('timeout');
 const PERCENTILES = Symbol('percentiles');
-const BUCKET_INTERVAL = Symbol('emit-interval');
+const BUCKET_INTERVAL = Symbol('bucket-interval');
 const EMIT_INTERVAL = Symbol('emit-interval');
 
 const EventEmitter = require('events').EventEmitter;

--- a/lib/status.js
+++ b/lib/status.js
@@ -5,7 +5,7 @@ const BUCKETS = Symbol('buckets');
 const TIMEOUT = Symbol('timeout');
 const PERCENTILES = Symbol('percentiles');
 const BUCKET_INTERVAL = Symbol('bucket-interval');
-const EMIT_INTERVAL = Symbol('emit-interval');
+const SNAPSHOT_INTERVAL = Symbol('snapshot-interval');
 
 const EventEmitter = require('events').EventEmitter;
 
@@ -78,10 +78,10 @@ class Status extends EventEmitter {
      * @event Status#snapshot
      * @type {Object}
      */
-    this[EMIT_INTERVAL] = setInterval(_ => this.emit('snapshot', this.stats),
+    this[SNAPSHOT_INTERVAL] = setInterval(_ => this.emit('snapshot', this.stats),
       bucketInterval);
-    if (typeof this[EMIT_INTERVAL].unref === 'function') {
-      this[EMIT_INTERVAL].unref();
+    if (typeof this[SNAPSHOT_INTERVAL].unref === 'function') {
+      this[SNAPSHOT_INTERVAL].unref();
     }
   }
 
@@ -162,7 +162,7 @@ class Status extends EventEmitter {
   shutdown () {
     this.removeAllListeners();
     clearInterval(this[BUCKET_INTERVAL]);
-    clearInterval(this[EMIT_INTERVAL]);
+    clearInterval(this[SNAPSHOT_INTERVAL]);
   }
 }
 

--- a/lib/status.js
+++ b/lib/status.js
@@ -78,7 +78,8 @@ class Status extends EventEmitter {
      * @event Status#snapshot
      * @type {Object}
      */
-    this[SNAPSHOT_INTERVAL] = setInterval(_ => this.emit('snapshot', this.stats),
+    this[SNAPSHOT_INTERVAL] = setInterval(
+      _ => this.emit('snapshot', this.stats),
       bucketInterval);
     if (typeof this[SNAPSHOT_INTERVAL].unref === 'function') {
       this[SNAPSHOT_INTERVAL].unref();

--- a/lib/status.js
+++ b/lib/status.js
@@ -4,6 +4,8 @@ const WINDOW = Symbol('window');
 const BUCKETS = Symbol('buckets');
 const TIMEOUT = Symbol('timeout');
 const PERCENTILES = Symbol('percentiles');
+const BUCKET_INTERVAL = Symbol('emit-interval');
+const EMIT_INTERVAL = Symbol('emit-interval');
 
 const EventEmitter = require('events').EventEmitter;
 
@@ -62,10 +64,13 @@ class Status extends EventEmitter {
 
     // rotate the buckets periodically
     const bucketInterval = Math.floor(this[TIMEOUT] / this[BUCKETS]);
-    let interval = setInterval(nextBucket(this[WINDOW]), bucketInterval);
+    this[BUCKET_INTERVAL] = setInterval(nextBucket(this[WINDOW]),
+      bucketInterval);
 
     // No unref() in the browser
-    if (typeof interval.unref === 'function') interval.unref();
+    if (typeof this[BUCKET_INTERVAL].unref === 'function') {
+      this[BUCKET_INTERVAL].unref();
+    }
 
     /**
      * Emitted at each time-slice. Listeners for this
@@ -73,9 +78,11 @@ class Status extends EventEmitter {
      * @event Status#snapshot
      * @type {Object}
      */
-    interval = setInterval(_ => this.emit('snapshot', this.stats),
+    this[EMIT_INTERVAL] = setInterval(_ => this.emit('snapshot', this.stats),
       bucketInterval);
-    if (typeof interval.unref === 'function') interval.unref();
+    if (typeof this[EMIT_INTERVAL].unref === 'function') {
+      this[EMIT_INTERVAL].unref();
+    }
   }
 
   /**
@@ -154,6 +161,8 @@ class Status extends EventEmitter {
 
   shutdown () {
     this.removeAllListeners();
+    clearInterval(this[BUCKET_INTERVAL]);
+    clearInterval(this[EMIT_INTERVAL]);
   }
 }
 


### PR DESCRIPTION
after shutting down a circuit breaker, these status intervals are persisted and continue to run. This keeps track of each interval and shuts them down.

Edit: attempting to fix the following warning from jest when using `jest --detectOpenHandles`

```
Jest has detected the following 2 open handles potentially keeping Jest from exiting:

  ●  Timeout



      at new Status (node_modules/opossum/lib/status.js:65:20)
      at new CircuitBreaker (node_modules/opossum/lib/circuit.js:119:20)
```