### PR TITLE
Do not close if earlier task resolves when state is not OPEN

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -187,7 +187,11 @@ class CircuitBreaker extends EventEmitter {
     }
 
     this.on('open', _startTimer(this));
-    this.on('success', _ => this.close());
+    this.on('success', _ => {
+      if (this.halfOpen) {
+        this.close();
+      }
+    });
     if (this.options.cache) {
       CACHE.set(this, undefined);
     }

--- a/test/closed-test.js
+++ b/test/closed-test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const test = require('tape');
+const CircuitBreaker = require('../');
+
+test(
+  'When closed, an existing request resolving does not reopen circuit',
+  t => {
+    t.plan(6);
+    const options = {
+      errorThresholdPercentage: 1,
+      resetTimeout: 60000
+    };
+
+    const breaker = new CircuitBreaker(function (shouldPass, time) {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          shouldPass
+            ? () => resolve('success')
+            : () => reject(new Error('test-error')),
+          time || 0
+        );
+        if (typeof timer.unref === 'function') {
+          timer.unref();
+        }
+      });
+    }, options);
+
+    const promises = [];
+
+    promises.push(breaker.fire(true, 100)
+      .then(res => t.equals(res, 'success')));
+
+    promises.push(breaker.fire(false)
+      .then(t.fail)
+      .catch(e => {
+        t.equals(e.message, 'test-error');
+      })
+      .then(() => {
+        t.ok(breaker.opened, 'should be open after initial fire');
+        t.notOk(breaker.pendingClose,
+          'should not be pending close after initial fire');
+      }));
+
+    Promise.all(promises)
+      .then(() => {
+        t.ok(breaker.opened, 'should still be open even after first fire resolved');
+        t.notOk(breaker.pendingClose,
+          'should still not be pending close');
+      })
+      .then(() => t.end());
+  }
+);

--- a/test/closed-test.js
+++ b/test/closed-test.js
@@ -44,7 +44,8 @@ test(
 
     Promise.all(promises)
       .then(() => {
-        t.ok(breaker.opened, 'should still be open even after first fire resolved');
+        t.ok(breaker.opened,
+          'should still be open even after first fire resolved');
         t.notOk(breaker.pendingClose,
           'should still not be pending close');
       })


### PR DESCRIPTION
The breaker would close if an earlier task resolved after a later one closed it. This fixes that.

fixes #381