### PR TITLE
Clear reset timer on open()

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -19,6 +19,7 @@ const ENABLED = Symbol('Enabled');
 const WARMING_UP = Symbol('warming-up');
 const VOLUME_THRESHOLD = Symbol('volume-threshold');
 const OUR_ERROR = Symbol('our-error');
+const RESET_TIMEOUT = Symbol('reset-timeout');
 const deprecation = `options.maxFailures is deprecated. \
 Please use options.errorThresholdPercentage`;
 
@@ -175,7 +176,7 @@ class CircuitBreaker extends EventEmitter {
 
     function _startTimer (circuit) {
       return _ => {
-        const timer = setTimeout(() => {
+        const timer = circuit[RESET_TIMEOUT] = setTimeout(() => {
           circuit[STATE] = HALF_OPEN;
           circuit[PENDING_CLOSE] = true;
           circuit.emit('halfOpen', circuit.options.resetTimeout);
@@ -218,6 +219,9 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   open () {
+    if (this[RESET_TIMEOUT]) {
+      clearTimeout(this[RESET_TIMEOUT]);
+    }
     this[PENDING_CLOSE] = false;
     if (this[STATE] !== OPEN) {
       this[STATE] = OPEN;
@@ -238,6 +242,9 @@ class CircuitBreaker extends EventEmitter {
   shutdown () {
     this.disable();
     this.removeAllListeners();
+    if (this[RESET_TIMEOUT]) {
+      clearTimeout(this[RESET_TIMEOUT]);
+    }
     this.status.shutdown();
     this[STATE] = SHUTDOWN;
     /**

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -20,6 +20,7 @@ const WARMING_UP = Symbol('warming-up');
 const VOLUME_THRESHOLD = Symbol('volume-threshold');
 const OUR_ERROR = Symbol('our-error');
 const RESET_TIMEOUT = Symbol('reset-timeout');
+const WARMUP_TIMEOUT = Symbol('warmup-timeout');
 const deprecation = `options.maxFailures is deprecated. \
 Please use options.errorThresholdPercentage`;
 
@@ -137,8 +138,10 @@ class CircuitBreaker extends EventEmitter {
     this[ENABLED] = options.enabled !== false;
 
     if (this[WARMING_UP]) {
-      const timer = setTimeout(_ => (this[WARMING_UP] = false),
-        this.options.rollingCountTimeout);
+      const timer = this[WARMUP_TIMEOUT] = setTimeout(
+        _ => (this[WARMING_UP] = false),
+        this.options.rollingCountTimeout
+      );
       if (typeof timer.unref === 'function') {
         timer.unref();
       }
@@ -244,6 +247,9 @@ class CircuitBreaker extends EventEmitter {
     this.removeAllListeners();
     if (this[RESET_TIMEOUT]) {
       clearTimeout(this[RESET_TIMEOUT]);
+    }
+    if (this[WARMUP_TIMEOUT]) {
+      clearTimeout(this[WARMUP_TIMEOUT]);
     }
     this.status.shutdown();
     this[STATE] = SHUTDOWN;

--- a/test/open-test.js
+++ b/test/open-test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('tape');
+const CircuitBreaker = require('../');
+const { timedFailingFunction } = require('./common');
+
+test('when open() is called it cancels the resetTimeout', t => {
+  t.plan(5);
+  const options = {
+    errorThresholdPercentage: 1,
+    resetTimeout: 100
+  };
+
+  const breaker = new CircuitBreaker(timedFailingFunction, options);
+  breaker.fire(0)
+    .then(t.fail)
+    .catch(e => t.equals(e, 'Failed after 0'))
+    .then(() => {
+      t.ok(breaker.opened, 'should be open after initial fire');
+      t.notOk(breaker.pendingClose,
+        'should not be pending close after initial fire');
+      breaker.open();
+    });
+
+  setTimeout(() => {
+    t.ok(breaker.opened, 'should not have been opened by the resetTimeout');
+    t.notOk(breaker.pendingClose,
+      'should still not be pending close');
+    t.end();
+  }, options.resetTimeout * 1.5);
+});


### PR DESCRIPTION
If `open()` is called I think the reset timer should be reset, as the intent is probably for the circuit breaker to remain open until `close()` is called.