### PR TITLE
Set entrypoint to dist/opossum.js

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -34,7 +34,7 @@ function generateConfig (name) {
   const config = {
     mode,
     entry: {
-      circuitBreaker: './index.js'
+      circuitBreaker: path.resolve(__dirname, '..', 'lib', 'circuit.js')
     },
     output: {
       path: path.resolve(__dirname, '..', 'dist'),

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = exports = require('./lib/circuit');

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "response": "REGULAR-7",
     "backing": "COMPANY"
   },
+  "main": "dist/opossum.js",
   "scripts": {
     "prebuild": "npm run lint",
     "build": "./test/browser/generate-index.sh && npm run build:browser && npm run build:docs",
     "build:browser": "webpack --config=config/webpack.config.js",
     "build:docs": "npm run build:docs:html && npm run build:docs:markdown",
-    "build:docs:html": "documentation build index.js -f html -o docs --config documentation.yml",
-    "build:docs:markdown": "documentation build index.js -f md -o docs/opossum.md",
+    "build:docs:html": "documentation build lib -f html -o docs --config documentation.yml",
+    "build:docs:markdown": "documentation build lib -f md -o docs/opossum.md",
     "pretest": "npm run lint",
     "test": "nyc tape test/*.js | tap-spec",
     "test:headless": "node test/browser/webpack-test.js",
@@ -23,7 +24,7 @@
     "ci": "npm run build && npm run test && npm run test:headless && npm run coverage",
     "prerelease": "npm run ci",
     "release": "standard-version -s -a",
-    "lint": "standardx test/*.js index.js lib/*.js test/*/*.js",
+    "lint": "standardx test/*.js lib/*.js test/*/*.js",
     "clean": "rm -rf node_modules dist/*.js test/browser/webpack-test.js"
   },
   "standard-version": {
@@ -40,10 +41,8 @@
     "package.json",
     "README.md",
     "LICENSE",
-    "index.js",
-    "lib",
     "dist",
-    "doc/opossum.md"
+    "docs/opossum.md"
   ],
   "bugs": {
     "url": "https://github.com/nodeshift/opossum/issues"

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 require('../circuit-shutdown-test.js');
+require('../closed-test.js');
 require('../common.js');
 require('../context-test.js');
 require('../enable-disable-test.js');

--- a/test/circuit-shutdown-test.js
+++ b/test/circuit-shutdown-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('..');
+const CircuitBreaker = require('../lib/circuit');
 const passFail = require('./common').passFail;
 
 // tests that we are not leaving listeners open to

--- a/test/closed-test.js
+++ b/test/closed-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 
 test(
   'When open, an existing request resolving does not close circuit',

--- a/test/context-test.js
+++ b/test/context-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 
 const context = {
   lunch: 'sushi'

--- a/test/enable-disable-test.js
+++ b/test/enable-disable-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 const { passFail } = require('./common');
 
 test('Defaults to enabled', t => {

--- a/test/error-filter-test.js
+++ b/test/error-filter-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 
 function mightFail (errorCode) {
   const err = new Error('Something went wrong');

--- a/test/half-open-test.js
+++ b/test/half-open-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 const { timedFailingFunction } = require('./common');
 
 test('When half-open, the circuit only allows one request through', t => {

--- a/test/health-check-test.js
+++ b/test/health-check-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 const common = require('./common');
 
 test('Circuits accept a health check function', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 const browser = require('./browser/browser-tap');
 const test = require('tape');
 const { promisify } = require('util');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 
 browser.enable();
 

--- a/test/volume-threshold-test.js
+++ b/test/volume-threshold-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 const { passFail } = require('./common');
 
 test('By default does not have a volume threshold', t => {

--- a/test/warmup-test.js
+++ b/test/warmup-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const CircuitBreaker = require('../');
+const CircuitBreaker = require('../lib/circuit');
 const { passFail } = require('./common');
 
 test('By default does not allow for warmup', t => {


### PR DESCRIPTION
With https://github.com/nodeshift/opossum/pull/380 and https://github.com/nodeshift/opossum/releases/tag/v4.2.0, we are now using Babel to transpile our distribution.

However, I was perplexed... I still get the same error as before, where my app is choking on the use of template literals. I realized the problem is because the distribution folder is not used at all by this library. We ship a transpiled and minified dependency, but don't use either of them by default, because the entrypoint is set to the library path. For the moment I can bypass the error by explicitly using the dist path in my app... `require('opossum/dist/opossum')`.

This pull request updates the package to point to the transpiled distribution of Opossum. Additionally, it only ships the `dist` folder, not the `lib`, so the package size is reduced. I confirmed this fixes my issue as well.