### PR TITLE
fix(circuit): allow timeout option to be false

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -32,7 +32,8 @@ Please use options.errorThresholdPercentage`;
  * @param {Function} action The action to fire for this {@link CircuitBreaker}
  * @param {Object} options Options for the {@link CircuitBreaker}
  * @param {Number} options.timeout The time in milliseconds that action should
- * be allowed to execute before timing out. Default 10000 (10 seconds)
+ * be allowed to execute before timing out. Timeout can be disabled by setting
+ * this to `false`. Default 10000 (10 seconds)
  * @param {Number} options.maxFailures (Deprecated) The number of times the
  * circuit can fail before opening. Default 10.
  * @param {Number} options.resetTimeout The time in milliseconds to wait before
@@ -112,7 +113,8 @@ class CircuitBreaker extends EventEmitter {
   constructor (action, options = {}) {
     super();
     this.options = options;
-    this.options.timeout = options.timeout || 10000;
+    this.options.timeout =
+      options.timeout === false ? false : options.timeout || 10000;
     this.options.resetTimeout = options.resetTimeout || 30000;
     this.options.errorThresholdPercentage =
       options.errorThresholdPercentage || 50;

--- a/test/test.js
+++ b/test/test.js
@@ -931,6 +931,30 @@ test('CircuitBreaker default capacity', t => {
   t.end();
 });
 
+test('CircuitBreaker without a timeout', t => {
+  t.plan(1);
+
+  const breaker = new CircuitBreaker(identity, { timeout: false });
+  const origTimeout = setTimeout;
+  let spyCalled = false;
+  // eslint-disable-next-line no-global-assign
+  setTimeout = () => {
+    spyCalled = true;
+  };
+
+  t.on('end', () => {
+    setTimeout = origTimeout; // eslint-disable-line no-global-assign
+  });
+
+  breaker.fire('foo')
+    .then(() => {
+      t.equals(spyCalled, false);
+      breaker.shutdown();
+      t.end();
+    })
+    .catch(t.fail);
+});
+
 const noop = _ => {};
 const common = require('./common');
 const identity = common.identity;


### PR DESCRIPTION
Allow `false` to be provided for the `timeout` option as a means of disabling the entire feature.

Note that the logic to skip the timeout feature if the option is falsey was still in place was did not need an update for this fix.
https://github.com/nodeshift/opossum/blob/30a83b361fc0e61f111ff846709712e9c476c77d/lib/circuit.js#L495

I'm not sure a good way to test this beyond monkey-patching the global `setTimeout` and asserting it wasn't called. So I haven't added a test, but would be happy to add one if there is a preferred method. 

Fixes #393.