### PR TITLE
chore: remove node8 from circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,16 +29,6 @@ build-common: &common-build
     - run: npm run ci
 
 jobs:
-  node8:
-    docker:
-      - image: circleci/node:8
-    <<: *common-build
-
-    filters:
-      branches:
-        ignore:
-          - gh-pages
-
   node10:
     docker:
       - image: circleci/node:10
@@ -63,7 +53,5 @@ workflows:
   version: 2
   test_node_versions:
     jobs:
-      - node8
       - node10
       - node12
-    


### PR DESCRIPTION
we've already updated the engine param in the package.json,  but we need to also remove the node8 tests from the circleci config

this will just be a patch release since we've already did the "remove node 8" stuff 