### PR TITLE
fix(test): Avoiding an UnhandledPromiseRejection

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -250,7 +250,7 @@ test(
     const breaker = new CircuitBreaker(passFail,
       { errorThresholdPercentage: 1, resetTimeout });
 
-    breaker.fire(fails);
+    breaker.fire(fails).catch(_ => {});
     breaker.fire(fails)
       .catch(() => {
         // Now the breaker should be open. Wait for reset and


### PR DESCRIPTION
This commit avoids an UnhandledPromiseRejectionWarning to be throwing
from `'Breaker resets after a configurable amount of time when multiple
jobs fail'` test.