### PR TITLE
build: use pull_request_target in actions workflow

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -3,7 +3,7 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
Coverage uploads require access to a repository secret, which isn't
accessible to pull requests from forks with the `pull_request` event.

Refs: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks