### PR TITLE
feat: pass circuit params to error filter

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -648,7 +648,7 @@ class CircuitBreaker extends EventEmitter {
 function handleError (error, circuit, timeout, args, latency, resolve, reject) {
   clearTimeout(timeout);
 
-  if (circuit.options.errorFilter(error)) {
+  if (circuit.options.errorFilter(error, ...args)) {
     circuit.emit('success', error, latency);
   } else {
     fail(circuit, error, args, latency);

--- a/test/error-filter-test.js
+++ b/test/error-filter-test.js
@@ -9,7 +9,7 @@ const options = {
   resetTimeout: 10000,
   // if this function returns true, the error statistics
   // should not be incremented
-  errorFilter: err => err.statusCode < 500
+  errorFilter: (err) => err.statusCode < 500
 };
 
 test('Bypasses failure stats if errorFilter returns true', t => {
@@ -52,5 +52,25 @@ test('Increments failure stats if no filter is provided', t => {
       t.equal(breaker.stats.failures, 1);
       t.ok(breaker.open);
       t.end();
+    });
+});
+
+test('Provides invocation parameters to error filter', t => {
+  t.plan(3);
+  const errorCode = 504;
+  const breaker = new CircuitBreaker(failWithCode,
+    {
+      errorThresholdPercentage: 1,
+      errorFilter: (err, param) => {
+        t.equal(param, errorCode);
+        t.equal(err.statusCode, errorCode);
+      }
+    }
+  );
+  breaker.fire(errorCode)
+    .then(t.fail)
+    .catch(err => {
+      t.equal(err.statusCode, errorCode);
+      t.end()
     });
 });


### PR DESCRIPTION
When the circuit invocation fails, and there is an error filter in place,
this change provides the function invocation parameters as the second
parameter to `errorFilter()`.

Fixes: https://github.com/nodeshift/opossum/issues/489

Signed-off-by: Lance Ball <lball@redhat.com>