### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -24,5 +24,20 @@ jobs:
     - run: npm ci
     - run: npm test
     - run: npx @pkgjs/support validate
-    - run: echo 'repo_token:' ${{ secrets.COVERALLS_GITHUB_TOKEN }} > ./.coveralls.yml
-    - run: node_modules/nyc/bin/nyc.js report --reporter=text-lcov | node_modules/coveralls/bin/coveralls.js
+    - run: node_modules/nyc/bin/nyc.js report --reporter=lcovonly
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.node-version }}
+        parallel: true
+
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -3,7 +3,7 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
- Revert 814cd4f4f10796a475ff7b032a44a822fef0bdae as this makes the CI job run with the base commit of the master branch and not the pull request head (see https://github.com/nodeshift/opossum/pull/499#issuecomment-732126270).
- Switch to using the coveralls GitHub action. Will need to do a follow up test to see if pull requests from forks behave better than before 814cd4f4f10796a475ff7b032a44a822fef0bdae but we should be no worse off.