### PR TITLE
fix: using default parameter to avoid runtime error

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -110,7 +110,7 @@ class CircuitBreaker extends EventEmitter {
     return !!error[OUR_ERROR];
   }
 
-  constructor (action, options = {}) {
+  constructor (action = {}, options = {}) {
     super();
     this.options = options;
     this.options.timeout =


### PR DESCRIPTION
This is a quick fix to avoid the following error when no action is passed in the constructor:

TypeError: Cannot read property 'name' of undefined

Related to #514 