### PR TITLE
docs: Fix documentation for default value of rollingPercentilesEnabled

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -52,7 +52,7 @@ Please use options.errorThresholdPercentage`;
  * @param {boolean} options.rollingPercentilesEnabled This property indicates
  * whether execution latencies should be tracked and calculated as percentiles.
  * If they are disabled, all summary statistics (mean, percentiles) are
- * returned as -1. Default: false
+ * returned as -1. Default: true
  * @param {Number} options.capacity the number of concurrent requests allowed.
  * If the number currently executing function calls is equal to
  * options.capacity, further calls to `fire()` are rejected until at least one


### PR DESCRIPTION
This PR is a very small documentation fix. The `rollingPercentilesEnabled` option is documented as defaulting to false, but rolling percentiles are [enabled by default](https://github.com/nodeshift/opossum/blob/16341bb806c14fec29cb25e7bd301e975ae23631/lib/circuit.js#L123) (and the corresponding [test](https://github.com/nodeshift/opossum/blob/16341bb806c14fec29cb25e7bd301e975ae23631/test/test.js#L811)) unless `rollingPercentilesEnabled` is explicitly set to `false`. 