### PR TITLE
chore(node): support Node.js 16

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rate-limiting"
   ],
   "engines": {
-    "node": "^15 || ^14 || ^12 || ^10"
+    "node": "^16 || ^14 || ^12 || ^10"
   },
   "dependencies": {},
   "support": true


### PR DESCRIPTION
Node.js 16 released. I think we can use 16 now.
For 15, since it is a short life version, so I think we can remove it.
(If you have concern to let Node.js 15 apps have a smooth migrating, just let me know. I can leave 15 there)
Thanks!