### PR TITLE
feat: initialize the state of a breaker on creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,23 +91,28 @@ breaker.fallback((delay, a, b, c) => `Sorry, out of service right now. But your 
 
 There may be times where you will need to initialize the state of a Circuit Breaker.  Primary use cases for this are in a serverless environment such as Knative or AWS Lambda, or any container based platform, where the container being deployed is ephemeral.
 
-The `exportState` method is a helper function to get the current state of a breaker:
+The `toJSON` method is a helper function to get the current state and status of a breaker:
 
 ```
-breaker.exportState();
+const breakerState = breaker.toJSON();
 ```
 
 This will return an object that might look similar to this:
 
 ```
-const state = {
-  enabled: true,
-  closed: true,
-  open: false,
-  halfOpen: false,
-  warmUp: false,
-  pendingClose: false,
-  shutdown: false
+{
+  state: {
+    enabled: true,
+    name: 'functionName'
+    closed: true,
+    open: false,
+    halfOpen: false,
+    warmUp: false,
+    shutdown: false
+  },
+  status: {
+    ...
+  }
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,39 @@ const breaker = new CircuitBreaker(delay);
 breaker.fire(20000, 1, 2, 3);
 breaker.fallback((delay, a, b, c) => `Sorry, out of service right now. But your parameters are: ${delay}, ${a}, ${b} and ${c}`);
 ```
+### Breaker State Initialization
+
+There may be times where you will need to initialize the state of a Circuit Breaker.  Primary use cases for this are in a serverless environment such as Knative or AWS Lambda, or any container based platform, where the container being deployed is ephemeral.
+
+The `exportState` method is a helper function to get the current state of a breaker:
+
+```
+breaker.exportState();
+```
+
+This will return an object that might look similar to this:
+
+```
+const state = {
+  enabled: true,
+  closed: true,
+  open: false,
+  halfOpen: false,
+  warmUp: false,
+  pendingClose: false,
+  shutdown: false
+};
+```
+
+A new circuit breaker instance can be created with this state by passing this object in:
+
+```
+const breaker = new CircuitBreaker({state: state});
+```
+
 ### Status Initialization
 
-There may be times where you will need to pre-populate the stats of the Circuit Breaker Status Object.  Primary use cases for this are in a serverless environment such as Knative or AWS Lambda, or any container based platform, where the container being deployed is ephemeral.
+There may also be times where you will need to pre-populate the stats of the Circuit Breaker Status Object.  Primary use cases for this are also in a serverless environment such as Knative or AWS Lambda, or any container based platform, where the container being deployed is ephemeral.
 
 Getting the existing cumalative stats for a breaker can be done like this:
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -157,7 +157,12 @@ class CircuitBreaker extends EventEmitter {
 
     // The user can pass in a Status object to inialize the Status/stats
     if (this.options.status) {
-      this[STATUS] = new Status({ stats: this.options.status });
+      // Do a check that this is a Status Object,
+      if (!(this.options.status instanceof Status)) {
+        this[STATUS] = new Status(this.options.status);
+      } else {
+        this[STATUS] = this.options.status;
+      }
     } else {
       this[STATUS] = new Status(this.options);
     }

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -168,17 +168,22 @@ class CircuitBreaker extends EventEmitter {
       this[STATUS] = new Status(this.options);
     }
 
+    this[STATE] = CLOSED;
+
     if (options.state) {
       this[ENABLED] = options.state.enabled !== false;
       this[WARMING_UP] = options.state.warmUp || this[WARMING_UP];
-      this[CLOSED] = options.state.closed || false;
-      this[OPEN] = options.state.open || false;
+      // Closed if nothing is passed in
+      this[CLOSED] = options.state.closed !== false;
       // These should be in sync
       this[HALF_OPEN] = this[PENDING_CLOSE] = options.state.halfOpen || false;
+      // Open should be the opposite of closed,
+      // but also the opposite of half_open
+      this[OPEN] = !this[CLOSED] && !this[HALF_OPEN];
+
       this[SHUTDOWN] = options.state.shutdown || false;
 
     } else {
-      this[STATE] = CLOSED;
       this[PENDING_CLOSE] = false;
       this[ENABLED] = options.enabled !== false;
     }
@@ -254,10 +259,11 @@ class CircuitBreaker extends EventEmitter {
       CACHE.set(this, undefined);
     }
 
-     // Prepopulate the State of the Breaker
-    if (this[CLOSED]) {
-      // If the state is closed, we don't do anything?
-      this[STATE] = CLOSED;
+    // Prepopulate the State of the Breaker
+    if (this[SHUTDOWN]) {
+      this[STATE] = SHUTDOWN;
+      this.shutdown();
+    } else if (this[CLOSED]) {
       this.close();
     } else if (this[OPEN]) {
       // If the state being passed in is OPEN
@@ -266,11 +272,6 @@ class CircuitBreaker extends EventEmitter {
     } else if (this[HALF_OPEN]) {
       // Not sure if anythign needs to be done here
       this[STATE] = HALF_OPEN;
-    } else if (this[SHUTDOWN]) {
-      // IF the state of the circuit being passed in is SHUTDOWN
-      // Then i don't think we need to do anything either?
-      this[STATE] = SHUTDOWN;
-      this.shutdown();
     }
   }
 
@@ -412,16 +413,18 @@ class CircuitBreaker extends EventEmitter {
     return this[STATUS].stats;
   }
 
-  // This is only for convience
-  exportState () {
+  toJSON () {
     return {
-      enabled: this.enabled,
-      closed: this.closed,
-      open: this.opened,
-      halfOpen: this.halfOpen,
-      warmUp: this.warmUp,
-      pendingClose: this.pendingClose,
-      shutdown: this.isShutdown
+      state: {
+        name: this.name,
+        enabled: this.enabled,
+        closed: this.closed,
+        open: this.opened,
+        halfOpen: this.halfOpen,
+        warmUp: this.warmUp,
+        shutdown: this.isShutdown
+      },
+      status: this.status.stats
     };
   }
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -170,11 +170,11 @@ class CircuitBreaker extends EventEmitter {
 
     if (options.state) {
       this[ENABLED] = options.state.enabled !== false;
-      this[PENDING_CLOSE] = options.state.pendingClose || false;
       this[WARMING_UP] = options.state.warmUp || this[WARMING_UP];
       this[CLOSED] = options.state.closed || false;
       this[OPEN] = options.state.open || false;
-      this[HALF_OPEN] = options.state.halfOpen || false;
+      // These should be in sync
+      this[HALF_OPEN] = this[PENDING_CLOSE] = options.state.halfOpen || false;
       this[SHUTDOWN] = options.state.shutdown || false;
 
     } else {

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -157,7 +157,7 @@ class CircuitBreaker extends EventEmitter {
 
     // The user can pass in a Status object to inialize the Status/stats
     if (this.options.status) {
-      this[STATUS] = new Status(this.options.status);
+      this[STATUS] = new Status({ stats: this.options.status });
     } else {
       this[STATUS] = new Status(this.options);
     }

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -157,13 +157,7 @@ class CircuitBreaker extends EventEmitter {
 
     // The user can pass in a Status object to inialize the Status/stats
     if (this.options.status) {
-      // Do a check that this is a Status Object,
-      if (this.options.status instanceof Status) {
-        this[STATUS] = this.options.status;
-      } else {
-        // should it error if it is not a Status Object
-        throw new TypeError('Not a Status Object.  The status option must be an instance of Status');
-      }
+      this[STATUS] = new Status(this.options.status);
     } else {
       this[STATUS] = new Status(this.options);
     }

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -168,12 +168,24 @@ class CircuitBreaker extends EventEmitter {
       this[STATUS] = new Status(this.options);
     }
 
-    this[STATE] = CLOSED;
+    if (options.state) {
+      this[ENABLED] = options.state.enabled !== false;
+      this[PENDING_CLOSE] = options.state.pendingClose || false;
+      this[WARMING_UP] = options.state.warmUp || this[WARMING_UP];
+      this[CLOSED] = options.state.closed || false;
+      this[OPEN] = options.state.open || false;
+      this[HALF_OPEN] = options.state.halfOpen || false;
+      this[SHUTDOWN] = options.state.shutdown || false;
+
+    } else {
+      this[STATE] = CLOSED;
+      this[PENDING_CLOSE] = false;
+      this[ENABLED] = options.enabled !== false;
+    }
+
     this[FALLBACK_FUNCTION] = null;
-    this[PENDING_CLOSE] = false;
     this[NAME] = options.name || action.name || nextName();
     this[GROUP] = options.group || this[NAME];
-    this[ENABLED] = options.enabled !== false;
 
     if (this[WARMING_UP]) {
       const timer = this[WARMUP_TIMEOUT] = setTimeout(
@@ -240,6 +252,25 @@ class CircuitBreaker extends EventEmitter {
     });
     if (this.options.cache) {
       CACHE.set(this, undefined);
+    }
+
+     // Prepopulate the State of the Breaker
+    if (this[CLOSED]) {
+      // If the state is closed, we don't do anything?
+      this[STATE] = CLOSED;
+      this.close();
+    } else if (this[OPEN]) {
+      // If the state being passed in is OPEN
+      // THen we need to start some timers
+      this.open();
+    } else if (this[HALF_OPEN]) {
+      // Not sure if anythign needs to be done here
+      this[STATE] = HALF_OPEN;
+    } else if (this[SHUTDOWN]) {
+      // IF the state of the circuit being passed in is SHUTDOWN
+      // Then i don't think we need to do anything either?
+      this[STATE] = SHUTDOWN;
+      this.shutdown();
     }
   }
 
@@ -379,6 +410,19 @@ class CircuitBreaker extends EventEmitter {
    */
   get stats () {
     return this[STATUS].stats;
+  }
+
+  // This is only for convience
+  exportState () {
+    return {
+      enabled: this.enabled,
+      closed: this.closed,
+      open: this.opened,
+      halfOpen: this.halfOpen,
+      warmUp: this.warmUp,
+      pendingClose: this.pendingClose,
+      shutdown: this.isShutdown
+    };
   }
 
   /**

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -158,10 +158,10 @@ class CircuitBreaker extends EventEmitter {
     // The user can pass in a Status object to inialize the Status/stats
     if (this.options.status) {
       // Do a check that this is a Status Object,
-      if (!(this.options.status instanceof Status)) {
-        this[STATUS] = new Status(this.options.status);
-      } else {
+      if (this.options.status instanceof Status) {
         this[STATUS] = this.options.status;
+      } else {
+        this[STATUS] = new Status({ stats: this.options.status });
       }
     } else {
       this[STATUS] = new Status(this.options);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:docs:markdown": "documentation build index.js -f md -o docs/opossum.md",
     "pretest": "eslint --ignore-path .gitignore .",
     "test": "nyc tape test/*.js | tap-spec",
+    "test:hrml": "nyc report --reporter=html",
     "test:headless": "node test/browser/webpack-test.js",
     "test:browser": "opener http://localhost:9007/test/browser/index.html && serve . -p 9007",
     "ci": "npm run build && npm run test && npm run test:headless",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "build:docs:markdown": "documentation build index.js -f md -o docs/opossum.md",
     "pretest": "eslint --ignore-path .gitignore .",
     "test": "nyc tape test/*.js | tap-spec",
-    "test:hrml": "nyc report --reporter=html",
     "test:headless": "node test/browser/webpack-test.js",
     "test:browser": "opener http://localhost:9007/test/browser/index.html && serve . -p 9007",
     "ci": "npm run build && npm run test && npm run test:headless",

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -83,8 +83,7 @@ test('When half-open, the circuit only allows one request through', t => {
     errorThresholdPercentage: 1,
     resetTimeout: 100,
     state: {
-      halfOpen: true,
-      pendingClose: true
+      halfOpen: true
     }
   };
 

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('tape');
+const CircuitBreaker = require('../');
+const { timedFailingFunction, passFail } = require('./common');
+
+test('CircuitBreaker State - export the state of a breaker instance', t => {
+  t.plan(8);
+  const breaker = new CircuitBreaker(passFail);
+
+  t.ok(breaker.exportState, 'has the exportState function');
+  const breakerState = breaker.exportState();
+
+  t.equal(breakerState.enabled, true, 'enabled initialized value');
+  t.equal(breakerState.closed, true, 'closed initialized value');
+  t.equal(breakerState.open, false, 'open initialized value');
+  t.equal(breakerState.halfOpen, false, 'half open initialized value');
+  t.equal(breakerState.warmUp, false, 'warmup initialized value');
+  t.equal(breakerState.pendingClose, false, 'pendingClose initialized value');
+  t.equal(breakerState.shutdown, false, 'shutdown initialized value');
+  t.end();
+});
+
+test('CircuitBreaker State - initalize the breaker as Closed', t => {
+  t.plan(9);
+
+  const state = {
+    enabled: true,
+    closed: true,
+    open: false,
+    halfOpen: false,
+    warmUp: false,
+    pendingClose: false,
+    shutdown: false
+  };
+
+  const breaker = new CircuitBreaker(passFail, {state});
+  const breakerState = breaker.exportState();
+
+  t.equal(breakerState.enabled, true, 'enabled primed value');
+  t.equal(breakerState.closed, true, 'closed primed value');
+  t.equal(breakerState.open, false, 'open primed value');
+  t.equal(breakerState.halfOpen, false, 'half open primed value');
+  t.equal(breakerState.warmUp, false, 'warmup primed value');
+  t.equal(breakerState.pendingClose, false, 'pendingClose primed value');
+  t.equal(breakerState.shutdown, false, 'shutdown primed value');
+
+  breaker.fire(-1).then(() => {
+    t.fail();
+  }).catch(() => {
+    t.equal(breaker.opened, true, 'breaker should be open');
+    t.equal(breaker.closed, false, 'breaker should not be closed');
+
+    t.end();
+  });
+});
+
+test('Pre-populate state as Open - Breaker resets after a configurable amount of time', t => {
+  t.plan(1);
+  const resetTimeout = 100;
+  const breaker = new CircuitBreaker(passFail, {
+    errorThresholdPercentage: 1,
+    resetTimeout,
+    state: {
+      open: true
+    }
+  });
+
+  // Now the breaker should be open. Wait for reset and
+  // fire again.
+  setTimeout(() => {
+    breaker.fire(100)
+      .catch(t.fail)
+      .then(arg => t.equals(arg, 100, 'breaker has reset'))
+      .then(_ => breaker.shutdown())
+      .then(t.end);
+  }, resetTimeout * 1.25);
+});
+
+test('When half-open, the circuit only allows one request through', t => {
+  t.plan(7);
+  const options = {
+    errorThresholdPercentage: 1,
+    resetTimeout: 100,
+    state: {
+      halfOpen: true,
+      pendingClose: true
+    }
+  };
+
+  const breaker = new CircuitBreaker(timedFailingFunction, options);
+  t.ok(breaker.halfOpen, 'should be halfOpen on initalize');
+  t.ok(breaker.pendingClose, 'should be pending close on initalize');
+
+  breaker
+    .fire(500) // fail after a long time, letting other fire()s occur
+    .catch(e => t.equals(e, 'Failed after 500', 'should fail again'))
+    .then(() => {
+      t.ok(breaker.opened,
+        'should be open again after long failing function');
+      t.notOk(breaker.halfOpen,
+        'should not be halfOpen after long failing function');
+      t.notOk(breaker.pendingClose,
+        'should not be pending close after long failing func');
+    })
+    .then(_ => {
+      // fire the breaker again, and be sure it fails as expected
+      breaker
+        .fire(1)
+        .catch(e => t.equals(e.message, 'Breaker is open'));
+    })
+    .then(_ => breaker.shutdown())
+    .then(t.end);
+});

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -5,29 +5,44 @@ const CircuitBreaker = require('../');
 const { timedFailingFunction, passFail } = require('./common');
 
 test('CircuitBreaker State - export the state of a breaker instance', t => {
+  t.plan(7);
+  const breaker = new CircuitBreaker(passFail);
+
+  t.ok(breaker.toJSON, 'has the toJSON function');
+  const breakerState = breaker.toJSON();
+
+  t.equal(breakerState.state.enabled, true, 'enabled initialized value');
+  t.equal(breakerState.state.closed, true, 'closed initialized value');
+  t.equal(breakerState.state.open, false, 'open initialized value');
+  t.equal(breakerState.state.halfOpen, false, 'half open initialized value');
+  t.equal(breakerState.state.warmUp, false, 'warmup initialized value');
+  t.equal(breakerState.state.shutdown, false, 'shutdown initialized value');
+  t.end();
+});
+
+test('CircuitBreaker State - export the state of a breaker instance using toJson', t => {
   t.plan(8);
   const breaker = new CircuitBreaker(passFail);
 
-  t.ok(breaker.exportState, 'has the exportState function');
-  const breakerState = breaker.exportState();
+  t.ok(breaker.toJSON, 'has the toJSON function');
+  const breakerState = breaker.toJSON();
 
-  t.equal(breakerState.enabled, true, 'enabled initialized value');
-  t.equal(breakerState.closed, true, 'closed initialized value');
-  t.equal(breakerState.open, false, 'open initialized value');
-  t.equal(breakerState.halfOpen, false, 'half open initialized value');
-  t.equal(breakerState.warmUp, false, 'warmup initialized value');
-  t.equal(breakerState.pendingClose, false, 'pendingClose initialized value');
-  t.equal(breakerState.shutdown, false, 'shutdown initialized value');
+  t.equal(breakerState.state.name, 'passFail', 'name initialized value');
+  t.equal(breakerState.state.enabled, true, 'enabled initialized value');
+  t.equal(breakerState.state.closed, true, 'closed initialized value');
+  t.equal(breakerState.state.open, false, 'open initialized value');
+  t.equal(breakerState.state.halfOpen, false, 'half open initialized value');
+  t.equal(breakerState.state.warmUp, false, 'warmup initialized value');
+  t.equal(breakerState.state.shutdown, false, 'shutdown initialized value');
   t.end();
 });
 
 test('CircuitBreaker State - initalize the breaker as Closed', t => {
-  t.plan(9);
+  t.plan(8);
 
   const state = {
     enabled: true,
     closed: true,
-    open: false,
     halfOpen: false,
     warmUp: false,
     pendingClose: false,
@@ -35,15 +50,14 @@ test('CircuitBreaker State - initalize the breaker as Closed', t => {
   };
 
   const breaker = new CircuitBreaker(passFail, {state});
-  const breakerState = breaker.exportState();
+  const breakerState = breaker.toJSON();
 
-  t.equal(breakerState.enabled, true, 'enabled primed value');
-  t.equal(breakerState.closed, true, 'closed primed value');
-  t.equal(breakerState.open, false, 'open primed value');
-  t.equal(breakerState.halfOpen, false, 'half open primed value');
-  t.equal(breakerState.warmUp, false, 'warmup primed value');
-  t.equal(breakerState.pendingClose, false, 'pendingClose primed value');
-  t.equal(breakerState.shutdown, false, 'shutdown primed value');
+  t.equal(breakerState.state.enabled, true, 'enabled primed value');
+  t.equal(breakerState.state.closed, true, 'closed primed value');
+  t.equal(breakerState.state.open, false, 'open primed value');
+  t.equal(breakerState.state.halfOpen, false, 'half open primed value');
+  t.equal(breakerState.state.warmUp, false, 'warmup primed value');
+  t.equal(breakerState.state.shutdown, false, 'shutdown primed value');
 
   breaker.fire(-1).then(() => {
     t.fail();
@@ -55,14 +69,14 @@ test('CircuitBreaker State - initalize the breaker as Closed', t => {
   });
 });
 
-test('Pre-populate state as Open - Breaker resets after a configurable amount of time', t => {
+test('Pre-populate state as Open(Closed === false) - Breaker resets after a configurable amount of time', t => {
   t.plan(1);
   const resetTimeout = 100;
   const breaker = new CircuitBreaker(passFail, {
     errorThresholdPercentage: 1,
     resetTimeout,
     state: {
-      open: true
+      closed: false
     }
   });
 
@@ -83,6 +97,7 @@ test('When half-open, the circuit only allows one request through', t => {
     errorThresholdPercentage: 1,
     resetTimeout: 100,
     state: {
+      closed: false,
       halfOpen: true
     }
   };
@@ -116,6 +131,8 @@ test('Circuit initalized as shutdown', t => {
   t.plan(5);
   const options = {
     state: {
+      closed: false,
+      open: false,
       shutdown: true
     }
   };

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -150,3 +150,26 @@ test('Circuit initalized as shutdown', t => {
       t.end();
     });
 });
+
+test('CircuitBreaker State - imports the state and status of a breaker instance', t => {
+  const breaker = new CircuitBreaker(passFail);
+  const exp = breaker.toJSON();
+  const state = exp.state;
+  const status = exp.status;
+  const clone = new CircuitBreaker(passFail, { state, status });
+  // test imported state
+  for (const stat of ['enabled', 'closed', 'halfOpen', 'warmUp']) {
+    t.equal(clone[status], state[status], `cloned breaker ${stat} state`);
+  }
+  t.equal(clone.opened, state.open, 'cloned breaker open state');
+  t.equal(clone.isShutdown, state.shutdown, 'cloned breaker shutdown state');
+  // test imported status
+  const stats = clone.stats;
+  for (const stat in stats) {
+    t.equal(
+      stats[stat].toString(),
+      status[stat].toString(),
+      `cloned stat ${stat} value`);
+  }
+  t.end();
+});

--- a/test/state-test.js
+++ b/test/state-test.js
@@ -111,3 +111,25 @@ test('When half-open, the circuit only allows one request through', t => {
     .then(_ => breaker.shutdown())
     .then(t.end);
 });
+
+test('Circuit initalized as shutdown', t => {
+  t.plan(5);
+  const options = {
+    state: {
+      shutdown: true
+    }
+  };
+  const breaker = new CircuitBreaker(passFail, options);
+  t.ok(breaker.isShutdown, 'breaker is shutdown');
+  t.notOk(breaker.enabled, 'breaker has been disabled');
+  breaker.fire(1)
+    .then(t.fail)
+    .catch(err => {
+      t.equals('ESHUTDOWN', err.code);
+      t.equals('The circuit has been shutdown.', err.message);
+      t.equals(
+        CircuitBreaker.isOurError(err), true, 'isOurError() should return true'
+      );
+      t.end();
+    });
+});

--- a/test/status-test.js
+++ b/test/status-test.js
@@ -130,3 +130,30 @@ test('CircuitBreaker status - import stats, but leave some out', t => {
   breaker.shutdown();
   t.end();
 });
+
+test('CircuitBreaker status - import stats,but not a status object', t => {
+  t.plan(1);
+
+  const prevStats = {
+    rejects: 1,
+    fires: 1,
+    timeouts: 1,
+    cacheHits: 1,
+    cacheMisses: 1,
+    semaphoreRejections: 1,
+    percentiles: {},
+    latencyTimes: []
+  };
+
+  try {
+    // eslint-disable-next-line
+    const _ = new CircuitBreaker(passFail, {
+      errorThresholdPercentage: 1,
+      status: prevStats
+    });
+    t.pass();
+    t.end();
+  } catch (err) {
+    t.fail();
+  }
+});

--- a/test/status-test.js
+++ b/test/status-test.js
@@ -130,30 +130,3 @@ test('CircuitBreaker status - import stats, but leave some out', t => {
   breaker.shutdown();
   t.end();
 });
-
-test('CircuitBreaker status - import stats,but not a status object', t => {
-  t.plan(1);
-
-  const prevStats = {
-    rejects: 1,
-    fires: 1,
-    timeouts: 1,
-    cacheHits: 1,
-    cacheMisses: 1,
-    semaphoreRejections: 1,
-    percentiles: {},
-    latencyTimes: []
-  };
-
-  try {
-    // eslint-disable-next-line
-    const _ = new CircuitBreaker(passFail, {
-      errorThresholdPercentage: 1,
-      status: prevStats
-    });
-    t.fail();
-  } catch (err) {
-    if (err instanceof TypeError) t.pass();
-    t.end();
-  }
-});


### PR DESCRIPTION
This PR is a continuation of #568.  That last PR only allowed a user to prime the circuit breaker with the stats of the circuit.  This part adds the ability to prime the breaker with a starting state.  To make it easier for users to see there state, and ultimately save it some where, the `exportState` function has been added.

To create a Circuit with states, there is now a `state` parameter in the options.  Creating a new circuit might look like this:

```

const state = {
....
}


const breaker = new CircuitBreaker({state: state});



// to export the state

const breakerState = breaker.exportState();
```
I updated the README with some samples of how this would work


The only part i'm not thrilled with is but is probably ok, is that during initilization, if you prime a circuit to be open, then the code emits an "open" event so that the proper timers runs, but it also increments the status count of open, even though the protected function never ran.  It probably isn't even an issue since it only will increment the status by 1.

 