### PR TITLE
fix: breaker should emit a shutdown event when it is shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Here are the events you can listen for.
   * `fallback` - emitted when the breaker has a fallback function and executes it
   * `semaphoreLocked` - emitted when the breaker is at capacity and cannot execute the request
   * `healthCheckFailed` - emitted when a user-supplied health check function returns a rejected promise
-  * `shutdown` - emitted when the breaker shutsdown
+  * `shutdown` - emitted when the breaker shuts down
 
 Handling events gives a greater level of control over your application behavior.
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Here are the events you can listen for.
   * `fallback` - emitted when the breaker has a fallback function and executes it
   * `semaphoreLocked` - emitted when the breaker is at capacity and cannot execute the request
   * `healthCheckFailed` - emitted when a user-supplied health check function returns a rejected promise
+  * `shutdown` - emitted when the breaker shutsdown
 
 Handling events gives a greater level of control over your application behavior.
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -323,6 +323,12 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   shutdown () {
+    /**
+     * Emitted when the circuit breaker has been shut down.
+     * @event CircuitBreaker#shutdown
+     */
+    this.emit('shutdown');
+
     this.disable();
     this.removeAllListeners();
     if (this[RESET_TIMEOUT]) {
@@ -333,11 +339,6 @@ class CircuitBreaker extends EventEmitter {
     }
     this.status.shutdown();
     this[STATE] = SHUTDOWN;
-    /**
-     * Emitted when the circuit breaker has been shut down.
-     * @event CircuitBreaker#shutdown
-     */
-    this.emit('shutdown');
   }
 
   /**

--- a/test/circuit-shutdown-test.js
+++ b/test/circuit-shutdown-test.js
@@ -17,8 +17,11 @@ test('EventEmitter max listeners', t => {
 });
 
 test('Circuit shuts down properly', t => {
-  t.plan(6);
+  t.plan(7);
   const breaker = new CircuitBreaker(passFail);
+  breaker.on('shutdown', _ => {
+    t.pass('Breaker emits Shutdown');
+  });
   t.ok(breaker.fire(1), 'breaker is active');
   breaker.shutdown();
   t.ok(breaker.isShutdown, 'breaker is shutdown');


### PR DESCRIPTION
fixes #620

currently, when shutdown is called, it removes all the listeners before it emits the shutdown event, this moves the call to emit the shutdown event before the listeners are removed