### PR TITLE
chore: remove the options.maxFailures condition check

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,9 +338,7 @@ The `errorThresholdPercentage` value is compared to the error rate. That rate is
   const stats = circuit.stats;
   if ((stats.fires < circuit.volumeThreshold) && !circuit.halfOpen) return;
   const errorRate = stats.failures / stats.fires * 100;
-  if (errorRate > circuit.options.errorThresholdPercentage ||
-    stats.failures >= circuit.options.maxFailures ||
-    circuit.halfOpen) {
+  if (errorRate > circuit.options.errorThresholdPercentage || circuit.halfOpen) {
     circuit.open();
   }
 ```

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -310,7 +310,7 @@ class CircuitBreaker extends EventEmitter {
       this[PENDING_CLOSE] = false;
       /**
        * Emitted when the breaker opens because the action has
-       * failed more than `options.maxFailures` number of times.
+       * failure percentage greater than `options.errorThresholdPercentage`.
        * @event CircuitBreaker#open
        */
       this.emit('open');
@@ -781,9 +781,7 @@ function fail (circuit, err, args, latency) {
   const stats = circuit.stats;
   if ((stats.fires < circuit.volumeThreshold) && !circuit.halfOpen) return;
   const errorRate = stats.failures / stats.fires * 100;
-  if (errorRate > circuit.options.errorThresholdPercentage ||
-    stats.failures >= circuit.options.maxFailures ||
-    circuit.halfOpen) {
+  if (errorRate > circuit.options.errorThresholdPercentage || circuit.halfOpen) {
     circuit.open();
   }
 }


### PR DESCRIPTION
remove the options.maxFailures condition check when deciding if the circuit should be opened

It's a bit misleading when looking at the source code, where we are still comparing the `options.maxFailures` value when deciding if the circuit should be opened. Same issue on the documentation. We should remove the deprecated option from the checking logic to avoid confusion