### PR TITLE
feat: adds `AbortController` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,44 @@ breaker.fire(x, y)
   .catch(console.error);
 ```
 
+### AbortController support
+
+You can provide an `AbortController` (https://developer.mozilla.org/en-US/docs/Web/API/AbortController, https://nodejs.org/docs/latest/api/globals.html#globals_class_abortcontroller) for aborting on going request upon
+reaching Opossum timeout.
+
+```javascript
+const CircuitBreaker = require('opossum');
+const http = require('http);
+
+function asyncFunctionThatCouldFail(abortSignal, x, y) {
+  return new Promise((resolve, reject) => {
+    http.get(
+      'http://httpbin.org/delay/10',
+      { signal: abortSignal },
+      (res) => {
+        if(res.statusCode < 300) {
+          resolve(res.statusCode);
+          return;
+        }
+
+        reject(res.statusCode);
+      }
+    );
+  });
+}
+
+const abortController = new AbortController();
+const options = {
+  abortController,
+  timeout: 3000, // If our function takes longer than 3 seconds, trigger a failure
+};
+const breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
+
+breaker.fire(abortController.signal)
+  .then(console.log)
+  .catch(console.error);
+```
+
 ### Fallback
 
 You can also provide a fallback function that will be executed in the

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -85,6 +85,9 @@ Please use options.errorThresholdPercentage`;
  * has been cached that value will be returned for every subsequent execution:
  * the cache can be cleared using `clearCache`. (The metrics `cacheHit` and
  * `cacheMiss` reflect cache activity.) Default: false
+ * @param {AbortController} options.abortController this allows Opossum to
+ * signal upon timeout and properly abort your on going requests instead of
+ * leaving it in the background
  *
  *
  * @fires CircuitBreaker#halfOpen
@@ -149,6 +152,12 @@ class CircuitBreaker extends EventEmitter {
     if (!action) {
       throw new TypeError(
         'No action provided. Cannot construct a CircuitBreaker without an invocable action.'
+      );
+    }
+
+    if (options.abortController && typeof options.abortController.abort !== 'function') {
+      throw new TypeError(
+        'AbortController does not contain `abort()` method'
       );
     }
 
@@ -598,6 +607,9 @@ class CircuitBreaker extends EventEmitter {
                */
               this.emit('timeout', error, latency, args);
               handleError(error, this, timeout, args, latency, resolve, reject);
+              if (this.options.abortController) {
+                this.options.abortController.abort();
+              }
             }, this.options.timeout);
         }
 


### PR DESCRIPTION
Addresses https://github.com/nodeshift/opossum/issues/673

This PR adds `AbortController` support in Opossum. This is useful in
conjunction with the timeout feature, where Opossum will signal upon
timeout and allow users to cleanly abort their ongoing requests.

See links:
- https://developer.mozilla.org/en-US/docs/Web/API/AbortController
- https://nodejs.org/api/globals.html#class-abortcontroller
- https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#aborting_a_fetch
- https://nodejs.org/api/http.html#httprequesturl-options-callback