### PR TITLE
feat: add cacheTTL option

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -86,6 +86,8 @@ Please use options.errorThresholdPercentage`;
  * has been cached that value will be returned for every subsequent execution:
  * the cache can be cleared using `clearCache`. (The metrics `cacheHit` and
  * `cacheMiss` reflect cache activity.) Default: false
+ * @param {Number} options.cacheTTL the time to live for the cache
+ * in milliseconds. Set 0 for infinity cache. Default: 0 (no TTL)
  * @param {AbortController} options.abortController this allows Opossum to
  * signal upon timeout and properly abort your on going requests instead of
  * leaving it in the background
@@ -146,6 +148,7 @@ class CircuitBreaker extends EventEmitter {
       ? options.capacity
       : Number.MAX_SAFE_INTEGER;
     this.options.errorFilter = options.errorFilter || (_ => false);
+    this.options.cacheTTL = options.cacheTTL ?? 0;
 
     this.semaphore = new Semaphore(this.options.capacity);
 
@@ -275,9 +278,6 @@ class CircuitBreaker extends EventEmitter {
         this.close();
       }
     });
-    if (this.options.cache) {
-      CACHE.set(this, undefined);
-    }
 
     // Prepopulate the State of the Breaker
     if (this[SHUTDOWN]) {
@@ -557,6 +557,9 @@ class CircuitBreaker extends EventEmitter {
     }
     const args = Array.prototype.slice.call(rest);
 
+    const cache = this.getCache();
+    const cacheKey = JSON.stringify(rest);
+
     /**
      * Emitted when the circuit breaker action is executed
      * @event CircuitBreaker#fire
@@ -564,15 +567,20 @@ class CircuitBreaker extends EventEmitter {
      */
     this.emit('fire', args);
 
-    if (CACHE.get(this) !== undefined) {
-      /**
-       * Emitted when the circuit breaker is using the cache
-       * and finds a value.
-       * @event CircuitBreaker#cacheHit
-       */
-      this.emit('cacheHit');
-      return CACHE.get(this);
-    } else if (this.options.cache) {
+    // If cache is enabled, check if we have a cached value
+    if (this.options.cache) {
+      const cached = cache.get(cacheKey);
+      if (cached &&
+        (cached.expiresAt === 0 || cached.expiresAt >= Date.now())
+      ) {
+        /**
+         * Emitted when the circuit breaker is using the cache
+         * and finds a value.
+         * @event CircuitBreaker#cacheHit
+         */
+        this.emit('cacheHit');
+        return cached.value;
+      }
       /**
        * Emitted when the circuit breaker does not find a value in
        * the cache, but the cache option is enabled.
@@ -649,7 +657,12 @@ class CircuitBreaker extends EventEmitter {
               this.semaphore.release();
               resolve(result);
               if (this.options.cache) {
-                CACHE.set(this, promise);
+                cache.set(cacheKey, {
+                  expiresAt: this.options.cacheTTL > 0
+                    ? Date.now() + this.options.cacheTTL
+                    : 0,
+                  value: promise
+                });
               }
             }
           })
@@ -686,7 +699,23 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   clearCache () {
-    CACHE.set(this, undefined);
+    CACHE.delete(this);
+  }
+
+  /**
+   * Return cache of this {@link CircuitBreaker}
+   * @returns {Map<any, {
+   *  expiresAt: number,
+   *  value: any
+   * }>} the cache of this {@link CircuitBreaker}
+   */
+  getCache () {
+    let cache = CACHE.get(this);
+    if (!(cache instanceof Map)) {
+      cache = new Map();
+      CACHE.set(this, cache);
+    }
+    return cache;
   }
 
   /**


### PR DESCRIPTION
# Problem
Current cache implementation not really useful in production, because it can store only first response, but this behaviour not good for a lot of cases. For example: I'm using Circuit Breaker to get config data and endpoint returns different responses based on arguments. I want it to be cached, but based on parameters.

# Solution
- `CACHE` still WeakMap, but value for now not response, but `Map` with cached values by arguments.
- Added `cacheTTL` option to update cached value after expiration time.

# Questions
- Not sure about adding cache cleaner, who will clean expired values from Map. This will add new timer and extra loop over cached values. Probably as extra option like `options.cacheCleanInterval` or `option.cacheCleaner`?
- Probably it make sense to make cache logic pluggable?
- Not sure should `getCache` method be private or not.