### PR TITLE
Reduce apply() calls to improve call times.

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -519,9 +519,7 @@ class CircuitBreaker extends EventEmitter {
   fallback (func) {
     let fb = func;
     if (func instanceof CircuitBreaker) {
-      fb = function () {
-        return func.fire.apply(func, arguments);
-      };
+      fb = (...args) => func.fire(...args);
     }
     this[FALLBACK_FUNCTION] = fb;
     return this;
@@ -550,7 +548,7 @@ class CircuitBreaker extends EventEmitter {
    * @fires CircuitBreaker#semaphoreLocked
    */
   fire (...args) {
-    return this.call.apply(this, [this.action].concat(args));
+    return this.call(this.action, ...args);
   }
 
   /**
@@ -582,7 +580,8 @@ class CircuitBreaker extends EventEmitter {
       const err = buildError('The circuit has been shutdown.', 'ESHUTDOWN');
       return Promise.reject(err);
     }
-    const args = Array.prototype.slice.call(rest);
+
+    const args = rest.slice();
 
     // Need to create variable here to prevent extra calls if cache is disabled
     let cacheKey = '';


### PR DESCRIPTION
This brings opossum.fire() roughly in line with hystrixjs.execute()

Reduces fire() call time by about 50%, and fallback call time by 30%

    fire() x 134,900 ops/sec ±42.25% (21 runs sampled)
    fire() error x 68,030 ops/sec ±31.60% (8 runs sampled)
    
    fire() x 286,626 ops/sec ±28.73% (56 runs sampled)
    fire() error x 99,637 ops/sec ±2.48% (10 runs sampled)
