### PR TITLE
chore: update github actions for coveralls

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -55,7 +55,7 @@ jobs:
         parallel: true
 
   finish:
-    needs: lts
+    needs: [lts, current]
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished


### PR DESCRIPTION
Ensures that the coveralls build is not closed until both `lts` and `current` jobs complete.