### PR TITLE
feat: add option to disable stats snapshots

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -158,6 +158,7 @@ class CircuitBreaker extends EventEmitter {
     this.options.cacheTTL = options.cacheTTL ?? 0;
     this.options.cacheGetKey = options.cacheGetKey ??
       ((...args) => JSON.stringify(args));
+    this.options.enableSnapshots = options.enableSnapshots !== false
 
     // Set default cache transport if not provided
     if (this.options.cache) {

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -158,7 +158,7 @@ class CircuitBreaker extends EventEmitter {
     this.options.cacheTTL = options.cacheTTL ?? 0;
     this.options.cacheGetKey = options.cacheGetKey ??
       ((...args) => JSON.stringify(args));
-    this.options.enableSnapshots = options.enableSnapshots !== false
+    this.options.enableSnapshots = options.enableSnapshots !== false;
 
     // Set default cache transport if not provided
     if (this.options.cache) {

--- a/lib/status.js
+++ b/lib/status.js
@@ -61,6 +61,9 @@ class Status extends EventEmitter {
     this.rollingPercentilesEnabled =
     options.rollingPercentilesEnabled !== false;
 
+    // Default this value to true
+    this.enableSnapshots = options.enableSnapshots !== false;
+
     // prime the window with buckets
     for (let i = 0; i < this[BUCKETS]; i++) this[WINDOW][i] = bucket();
 
@@ -80,11 +83,13 @@ class Status extends EventEmitter {
      * @event Status#snapshot
      * @type {Object}
      */
-    this[SNAPSHOT_INTERVAL] = setInterval(
-      _ => this.emit('snapshot', this.stats),
-      bucketInterval);
-    if (typeof this[SNAPSHOT_INTERVAL].unref === 'function') {
-      this[SNAPSHOT_INTERVAL].unref();
+    if (this.enableSnapshots) {
+      this[SNAPSHOT_INTERVAL] = setInterval(
+        _ => this.emit('snapshot', this.stats),
+        bucketInterval);
+      if (typeof this[SNAPSHOT_INTERVAL].unref === 'function') {
+        this[SNAPSHOT_INTERVAL].unref();
+      }
     }
 
     if (options.stats) {
@@ -169,7 +174,9 @@ class Status extends EventEmitter {
   shutdown () {
     this.removeAllListeners();
     clearInterval(this[BUCKET_INTERVAL]);
-    clearInterval(this[SNAPSHOT_INTERVAL]);
+    if (this.enableSnapshots) {
+      clearInterval(this[SNAPSHOT_INTERVAL]);
+    }
   }
 }
 

--- a/test/status-test.js
+++ b/test/status-test.js
@@ -157,3 +157,40 @@ test('CircuitBreaker status - import stats,but not a status object', t => {
     t.fail();
   }
 });
+
+test('CircuitBreaker status - enableSnapshots defaults to true', t => {
+  t.plan(1);
+
+  const breaker = new CircuitBreaker(passFail);
+
+  t.equal(breaker.status.enableSnapshots, true, 'enableSnapshots defaults to true');
+
+  breaker.shutdown();
+  t.end();
+});
+
+test('CircuitBreaker status - enableSnapshots is true in Status when set to true', t => {
+  t.plan(1);
+
+  const breaker = new CircuitBreaker(passFail, {
+    enableSnapshots: true
+  });
+
+  t.equal(breaker.status.enableSnapshots, true, 'enableSnapshots propagates as true');
+
+  breaker.shutdown();
+  t.end();
+});
+
+test('CircuitBreaker status - enableSnapshots is false in Status when set to false', t => {
+  t.plan(1);
+
+  const breaker = new CircuitBreaker(passFail, {
+    enableSnapshots: false
+  });
+
+  t.equal(breaker.status.enableSnapshots, false, 'enableSnapshots propagates as false');
+
+  breaker.shutdown();
+  t.end();
+});


### PR DESCRIPTION
Hello! I had a small feature request

Motivation

As I understand it, every bucket_interval (1s by default), opossum emits a snapshot of the stats in the Status class

this[SNAPSHOT_INTERVAL] = setInterval(_ => this.emit('snapshot', this.stats), bucketInterval);
My app doesn't actually listen to these stats and the extra call to setInterval clogs up the memory

Solution

Could we have a configurable option to disable the stats snapshots, thereby removing the extra call to setInterval?

Issue here: https://github.com/nodeshift/opossum/issues/798