### PR TITLE
fix: fix bug where options couldn't be set to zero.

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -151,13 +151,12 @@ class CircuitBreaker extends EventEmitter {
   constructor (action, options = {}) {
     super();
     this.options = options;
-    this.options.timeout =
-      options.timeout === false ? false : options.timeout || 10000;
-    this.options.resetTimeout = options.resetTimeout || 30000;
+    this.options.timeout = options.timeout ?? 10000;
+    this.options.resetTimeout = options.resetTimeout ?? 30000;
     this.options.errorThresholdPercentage =
-      options.errorThresholdPercentage || 50;
-    this.options.rollingCountTimeout = options.rollingCountTimeout || 10000;
-    this.options.rollingCountBuckets = options.rollingCountBuckets || 10;
+      options.errorThresholdPercentage ?? 50;
+    this.options.rollingCountTimeout = options.rollingCountTimeout ?? 10000;
+    this.options.rollingCountBuckets = options.rollingCountBuckets ?? 10;
     this.options.rollingPercentilesEnabled =
       options.rollingPercentilesEnabled !== false;
     this.options.capacity = Number.isInteger(options.capacity)

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -1,0 +1,90 @@
+const test = require('tape');
+const CircuitBreaker = require('../');
+
+const common = require('./common');
+const passFail = common.passFail;
+
+test('timeout defaults to 10000', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.timeout, 10000, 'should be set to 10000 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('timeout can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { timeout: 0 });
+  t.equals(breaker.options.timeout, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('resetTimeout defaults to 30000', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.resetTimeout, 30000, 'should be set to 30000 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('resetTimeout can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { resetTimeout: 0 });
+  t.equals(breaker.options.resetTimeout, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('errorThresholdPercentage defaults to 50', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.errorThresholdPercentage, 50, 'should be set to 50 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('errorThresholdPercentage can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { errorThresholdPercentage: 0 });
+  t.equals(breaker.options.errorThresholdPercentage, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountTimeout defaults to 10000', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.rollingCountTimeout, 10000, 'should be set to 10000 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountTimeout can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { rollingCountTimeout: 0 });
+  t.equals(breaker.options.rollingCountTimeout, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountBuckets defaults to 10', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.rollingCountBuckets, 10, 'should be set to 10 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountBuckets can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { rollingCountBuckets: 0 });
+  t.equals(breaker.options.rollingCountBuckets, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,74 @@ test('uses name as a group when no group is provided', t => {
   t.end();
 });
 
+test('errorThresholdPercentage defaults to 50', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.errorThresholdPercentage, 50, 'should be set to 50 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('errorThresholdPercentage can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { errorThresholdPercentage: 0 });
+  t.equals(breaker.options.errorThresholdPercentage, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('resetTimeout defaults to 30000', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.resetTimeout, 30000, 'should be set to 30000 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('resetTimeout can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { resetTimeout: 0 });
+  t.equals(breaker.options.resetTimeout, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountTimeout defaults to 10000', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.rollingCountTimeout, 10000, 'should be set to 10000 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountTimeout can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { rollingCountTimeout: 0 });
+  t.equals(breaker.options.rollingCountTimeout, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountBuckets defaults to 10', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail);
+  t.equals(breaker.options.rollingCountBuckets, 10, 'should be set to 10 by default');
+  breaker.shutdown();
+  t.end();
+});
+
+test('rollingCountBuckets can be set to 0', t => {
+  t.plan(1);
+  const breaker = new CircuitBreaker(passFail,
+    { rollingCountBuckets: 0 });
+  t.equals(breaker.options.rollingCountBuckets, 0, 'should be set to 0');
+  breaker.shutdown();
+  t.end();
+});
+
 test('Passes parameters to the circuit function', t => {
   t.plan(1);
   const expected = 34;


### PR DESCRIPTION
when setting things like resetTimeout and errorThresholdPercentage to 0, the default value was being used since zero is a false-y value.  Adding the [nullish coalesce operator (??)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#assigning_a_default_value_to_a_variable) fixes it 

fixes #824