### PR TITLE
perf: opossum

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -281,21 +281,6 @@ class CircuitBreaker extends EventEmitter {
 
     if (options.maxFailures) console.error(deprecation);
 
-    const increment = property =>
-      (result, runTime) => this[STATUS].increment(property, runTime);
-
-    this.on('success', increment('successes'));
-    this.on('failure', increment('failures'));
-    this.on('fallback', increment('fallbacks'));
-    this.on('timeout', increment('timeouts'));
-    this.on('fire', increment('fires'));
-    this.on('reject', increment('rejects'));
-    this.on('cacheHit', increment('cacheHits'));
-    this.on('cacheMiss', increment('cacheMisses'));
-    this.on('open', _ => this[STATUS].open());
-    this.on('close', _ => this[STATUS].close());
-    this.on('semaphoreLocked', increment('semaphoreRejections'));
-
     /**
      * @param {CircuitBreaker} circuit This current circuit
      * @returns {function(): void} A bound reset callback
@@ -378,6 +363,7 @@ class CircuitBreaker extends EventEmitter {
        * Emitted when the breaker is reset allowing the action to execute again
        * @event CircuitBreaker#close
        */
+      this[STATUS].close();
       this.emit('close');
     }
   }
@@ -400,6 +386,7 @@ class CircuitBreaker extends EventEmitter {
        * failure percentage greater than `options.errorThresholdPercentage`.
        * @event CircuitBreaker#open
        */
+      this[STATUS].open();
       this.emit('open');
     }
   }
@@ -585,7 +572,8 @@ class CircuitBreaker extends EventEmitter {
    * @fires CircuitBreaker#semaphoreLocked
    */
   fire (...args) {
-    return this.call(this.action, ...args);
+    args.unshift(this.action);
+    return this.call.apply(this, args);
   }
 
   /**
@@ -628,6 +616,7 @@ class CircuitBreaker extends EventEmitter {
      * @event CircuitBreaker#fire
      * @type {any} the arguments passed to the fired function
      */
+    this[STATUS].increment('fires');
     this.emit('fire', args);
 
     // If cache is enabled, check if we have a cached value
@@ -640,6 +629,7 @@ class CircuitBreaker extends EventEmitter {
          * and finds a value.
          * @event CircuitBreaker#cacheHit
          */
+        this[STATUS].increment('cacheHits');
         this.emit('cacheHit');
         return cached;
       }
@@ -648,6 +638,7 @@ class CircuitBreaker extends EventEmitter {
        * the cache, but the cache option is enabled.
        * @event CircuitBreaker#cacheMiss
        */
+      this[STATUS].increment('cacheMisses');
       this.emit('cacheMiss');
     }
 
@@ -666,6 +657,7 @@ class CircuitBreaker extends EventEmitter {
        */
       const error = buildError('Breaker is open', 'EOPENBREAKER');
 
+      this[STATUS].increment('rejects');
       this.emit('reject', error);
 
       return fallback(this, error, args) ||
@@ -693,6 +685,7 @@ class CircuitBreaker extends EventEmitter {
                * @event CircuitBreaker#timeout
                * @type {Error}
                */
+              this[STATUS].increment('timeouts', latency);
               this.emit('timeout', error, latency, args);
               handleError(error, this, timeout, args, latency, resolve, reject);
               if (this.options.abortController) {
@@ -715,7 +708,9 @@ class CircuitBreaker extends EventEmitter {
                * @event CircuitBreaker#success
                * @type {any} the return value from the circuit
                */
-              this.emit('success', result, (Date.now() - latencyStartTime));
+              const runTime = (Date.now() - latencyStartTime);
+              this[STATUS].increment('successes', runTime);
+              this.emit('success', result, runTime);
               this.semaphore.release();
               resolve(result);
               if (this.options.cache) {
@@ -751,6 +746,7 @@ class CircuitBreaker extends EventEmitter {
          * @event CircuitBreaker#semaphoreLocked
          * @type {Error}
          */
+        this[STATUS].increment('semaphoreRejections', latency);
         this.emit('semaphoreLocked', err, latency);
         handleError(err, this, timeout, args, latency, resolve, reject);
       }
@@ -844,6 +840,7 @@ function handleError (error, circuit, timeout, args, latency, resolve, reject) {
 
   if (circuit.options.errorFilter(error, ...args)) {
     // The error was filtered, so emit 'success'
+    circuit[STATUS].increment('successes', latency);
     circuit.emit('success', error, latency);
   } else {
     // Error was not filtered, so emit 'failure'
@@ -869,6 +866,7 @@ function fallback (circuit, err, args) {
        * @event CircuitBreaker#fallback
        * @type {any} the return value of the fallback function
        */
+      circuit[STATUS].increment('fallbacks', err);
       circuit.emit('fallback', result, err);
       if (result instanceof Promise) return result;
       return Promise.resolve(result);
@@ -884,6 +882,7 @@ function fail (circuit, err, args, latency) {
    * @event CircuitBreaker#failure
    * @type {Error}
    */
+  circuit[STATUS].increment('failures', latency);
   circuit.emit('failure', err, latency, args);
   if (circuit.warmUp) return;
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -13,6 +13,8 @@ const kStateShutdown = 1 << 5;
 const kStateWarmingUp = 1 << 6;
 const kStateEnabled = 1 << 7;
 
+const kCircuitFire = Symbol('kCircuitFire');
+
 const STATE_BITSET = Symbol('stateBitset');
 const STATE = Symbol('state');
 
@@ -572,8 +574,7 @@ class CircuitBreaker extends EventEmitter {
    * @fires CircuitBreaker#semaphoreLocked
    */
   fire (...args) {
-    args.unshift(this.action);
-    return this.call.apply(this, args);
+    return this[kCircuitFire](this.action, args);
   }
 
   /**
@@ -601,12 +602,14 @@ class CircuitBreaker extends EventEmitter {
    * @fires CircuitBreaker#semaphoreLocked
    */
   call (context, ...rest) {
+    return this[kCircuitFire](context, rest);
+  }
+
+  [kCircuitFire] (context, args) {
     if (this.isShutdown) {
       const err = buildError('The circuit has been shutdown.', 'ESHUTDOWN');
       return Promise.reject(err);
     }
-
-    const args = rest.slice();
 
     // Need to create variable here to prevent extra calls if cache is disabled
     let cacheKey = '';
@@ -621,7 +624,7 @@ class CircuitBreaker extends EventEmitter {
 
     // If cache is enabled, check if we have a cached value
     if (this.options.cache) {
-      cacheKey = this.options.cacheGetKey.apply(this, rest);
+      cacheKey = this.options.cacheGetKey.apply(this, args.slice());
       const cached = this.options.cacheTransport.get(cacheKey);
       if (cached) {
         /**

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -867,9 +867,12 @@ function handleError (error, circuit, timeout, args, latency, resolve, reject) {
 function fallback (circuit, err, args) {
   if (circuit[FALLBACK_FUNCTION]) {
     try {
+      // since this is the last method to be called,
+      // is safe to modify the args
+      args.push(err);
       const result =
-      circuit[FALLBACK_FUNCTION]
-        .apply(circuit[FALLBACK_FUNCTION], [...args, err]);
+        circuit[FALLBACK_FUNCTION]
+          .apply(circuit[FALLBACK_FUNCTION], args);
       /**
        * Emitted when the circuit breaker executes a fallback function
        * @event CircuitBreaker#fallback

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -30,6 +30,8 @@ const LAST_TIMER_AT = Symbol('last-timer-at');
 const deprecation = `options.maxFailures is deprecated. \
 Please use options.errorThresholdPercentage`;
 
+const noopErrorFilter = _ => false;
+
 function hasFlag (object, flag) {
   return (object[STATE_BITSET] & flag) > 0;
 }
@@ -171,7 +173,7 @@ class CircuitBreaker extends EventEmitter {
     this.options.capacity = Number.isInteger(options.capacity)
       ? options.capacity
       : Number.MAX_SAFE_INTEGER;
-    this.options.errorFilter = options.errorFilter || (_ => false);
+    this.options.errorFilter = options.errorFilter || noopErrorFilter;
     this.options.cacheTTL = options.cacheTTL ?? 0;
     this.options.cacheGetKey = options.cacheGetKey ??
       ((...args) => JSON.stringify(args));
@@ -841,7 +843,7 @@ class CircuitBreaker extends EventEmitter {
 function handleError (error, circuit, timeout, args, latency, resolve, reject) {
   clearTimeout(timeout);
 
-  if (circuit.options.errorFilter(error, ...args)) {
+  if (circuit.options.errorFilter !== noopErrorFilter && circuit.options.errorFilter(error, ...args)) {
     // The error was filtered, so emit 'success'
     circuit[STATUS].increment('successes', latency);
     circuit.emit('success', error, latency);

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -215,7 +215,9 @@ class CircuitBreaker extends EventEmitter {
       : 0;
     this[STATE_BITSET] = 0;
 
-    if (options.allowWarmUp === true) { this[STATE_BITSET] |= kStateWarmingUp; }
+    if (options.allowWarmUp === true) {
+      this[STATE_BITSET] |= kStateWarmingUp;
+    }
 
     // The user can pass in a Status object to initialize the Status/stats
     if (this.options.status) {
@@ -281,7 +283,9 @@ class CircuitBreaker extends EventEmitter {
 
     if (typeof action !== 'function') {
       this.action = _ => Promise.resolve(action);
-    } else this.action = action;
+    } else {
+      this.action = action;
+    }
 
     if (options.maxFailures) console.error(deprecation);
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -5,18 +5,21 @@ const Status = require('./status');
 const Semaphore = require('./semaphore');
 const MemoryCache = require('./cache');
 
+const kStateOpen = 1 << 1;
+const kStateClosed = 1 << 2;
+const kStateHalfOpen = 1 << 3;
+const kStatePendingClose = 1 << 4;
+const kStateShutdown = 1 << 5;
+const kStateWarmingUp = 1 << 6;
+const kStateEnabled = 1 << 7;
+
+const STATE_BITSET = Symbol('stateBitset');
 const STATE = Symbol('state');
-const OPEN = Symbol('open');
-const CLOSED = Symbol('closed');
-const HALF_OPEN = Symbol('half-open');
-const PENDING_CLOSE = Symbol('pending-close');
-const SHUTDOWN = Symbol('shutdown');
+
 const FALLBACK_FUNCTION = Symbol('fallback');
 const STATUS = Symbol('status');
 const NAME = Symbol('name');
 const GROUP = Symbol('group');
-const ENABLED = Symbol('Enabled');
-const WARMING_UP = Symbol('warming-up');
 const VOLUME_THRESHOLD = Symbol('volume-threshold');
 const OUR_ERROR = Symbol('our-error');
 const RESET_TIMEOUT = Symbol('reset-timeout');
@@ -24,6 +27,10 @@ const WARMUP_TIMEOUT = Symbol('warmup-timeout');
 const LAST_TIMER_AT = Symbol('last-timer-at');
 const deprecation = `options.maxFailures is deprecated. \
 Please use options.errorThresholdPercentage`;
+
+function hasFlag (object, flag) {
+  return (object[STATE_BITSET] & flag) > 0;
+}
 
 /**
  * Constructs a {@link CircuitBreaker}.
@@ -202,7 +209,9 @@ class CircuitBreaker extends EventEmitter {
     this[VOLUME_THRESHOLD] = Number.isInteger(options.volumeThreshold)
       ? options.volumeThreshold
       : 0;
-    this[WARMING_UP] = options.allowWarmUp === true;
+    this[STATE_BITSET] = 0;
+
+    if (options.allowWarmUp === true) { this[STATE_BITSET] |= kStateWarmingUp; }
 
     // The user can pass in a Status object to initialize the Status/stats
     if (this.options.status) {
@@ -216,31 +225,49 @@ class CircuitBreaker extends EventEmitter {
       this[STATUS] = new Status(this.options);
     }
 
-    this[STATE] = CLOSED;
+    this[STATE] = kStateClosed;
 
     if (options.state) {
-      this[ENABLED] = options.state.enabled !== false;
-      this[WARMING_UP] = options.state.warmUp || this[WARMING_UP];
+      if (options.state.enabled !== false) {
+        this[STATE_BITSET] |= kStateEnabled;
+      }
+
+      if (options.state.warmUp || hasFlag(this, kStateWarmingUp)) {
+        this[STATE_BITSET] |= kStateWarmingUp;
+      }
+
       // Closed if nothing is passed in
-      this[CLOSED] = options.state.closed !== false;
+      if (options.state.closed !== false) {
+        this[STATE_BITSET] |= kStateClosed;
+      }
+
       // These should be in sync
-      this[HALF_OPEN] = this[PENDING_CLOSE] = options.state.halfOpen || false;
+      if (options.state.halfOpen) {
+        this[STATE_BITSET] |= kStateHalfOpen | kStatePendingClose;
+      }
+
       // Open should be the opposite of closed,
       // but also the opposite of half_open
-      this[OPEN] = !this[CLOSED] && !this[HALF_OPEN];
-      this[SHUTDOWN] = options.state.shutdown || false;
+      if (!hasFlag(this, kStateClosed) && !hasFlag(this, kStateHalfOpen)) {
+        this[STATE_BITSET] |= kStateOpen;
+      }
+
+      if (options.state.shutdown) {
+        this[STATE_BITSET] |= kStateShutdown;
+      }
     } else {
-      this[PENDING_CLOSE] = false;
-      this[ENABLED] = options.enabled !== false;
+      if (options.enabled !== false) {
+        this[STATE_BITSET] |= kStateEnabled;
+      }
     }
 
     this[FALLBACK_FUNCTION] = null;
     this[NAME] = options.name || action.name || nextName();
     this[GROUP] = options.group || this[NAME];
 
-    if (this[WARMING_UP]) {
+    if (hasFlag(this, kStateWarmingUp)) {
       const timer = this[WARMUP_TIMEOUT] = setTimeout(
-        _ => (this[WARMING_UP] = false),
+        _ => (this[STATE_BITSET] &= ~kStateWarmingUp),
         this.options.rollingCountTimeout
       );
       if (typeof timer.unref === 'function') {
@@ -293,8 +320,8 @@ class CircuitBreaker extends EventEmitter {
      * @returns {void}
      */
     function _halfOpen (circuit) {
-      circuit[STATE] = HALF_OPEN;
-      circuit[PENDING_CLOSE] = true;
+      circuit[STATE] = kStateHalfOpen;
+      circuit[STATE_BITSET] |= kStatePendingClose;
       /**
        * Emitted after `options.resetTimeout` has elapsed, allowing for
        * a single attempt to call the service again. If that attempt is
@@ -314,12 +341,12 @@ class CircuitBreaker extends EventEmitter {
     });
 
     // Prepopulate the State of the Breaker
-    if (this[SHUTDOWN]) {
-      this[STATE] = SHUTDOWN;
+    if (hasFlag(this, kStateShutdown)) {
+      this[STATE] = kStateShutdown;
       this.shutdown();
-    } else if (this[CLOSED]) {
+    } else if (hasFlag(this, kStateClosed)) {
       this.close();
-    } else if (this[OPEN]) {
+    } else if (hasFlag(this, kStateOpen)) {
       // If the state being passed in is OPEN but more time has elapsed
       // than the resetTimeout, then we should be in halfOpen state
       if (this.options.state.lastTimerAt !== undefined &&
@@ -329,9 +356,9 @@ class CircuitBreaker extends EventEmitter {
       } else {
         this.open();
       }
-    } else if (this[HALF_OPEN]) {
+    } else if (hasFlag(this, kStateHalfOpen)) {
       // Not sure if anything needs to be done here
-      this[STATE] = HALF_OPEN;
+      this[STATE] = kStateHalfOpen;
     }
   }
 
@@ -341,12 +368,12 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   close () {
-    if (this[STATE] !== CLOSED) {
+    if (this[STATE] !== kStateClosed) {
       if (this[RESET_TIMEOUT]) {
         clearTimeout(this[RESET_TIMEOUT]);
       }
-      this[STATE] = CLOSED;
-      this[PENDING_CLOSE] = false;
+      this[STATE] = kStateClosed;
+      this[STATE_BITSET] &= ~kStatePendingClose;
       /**
        * Emitted when the breaker is reset allowing the action to execute again
        * @event CircuitBreaker#close
@@ -365,9 +392,9 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   open () {
-    if (this[STATE] !== OPEN) {
-      this[STATE] = OPEN;
-      this[PENDING_CLOSE] = false;
+    if (this[STATE] !== kStateOpen) {
+      this[STATE] = kStateOpen;
+      this[STATE_BITSET] &= ~kStatePendingClose;
       /**
        * Emitted when the breaker opens because the action has
        * failure percentage greater than `options.errorThresholdPercentage`.
@@ -398,7 +425,7 @@ class CircuitBreaker extends EventEmitter {
       clearTimeout(this[WARMUP_TIMEOUT]);
     }
     this.status.shutdown();
-    this[STATE] = SHUTDOWN;
+    this[STATE] = kStateShutdown;
 
     // clear cache on shutdown
     this.clearCache();
@@ -409,7 +436,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get isShutdown () {
-    return this[STATE] === SHUTDOWN;
+    return this[STATE] === kStateShutdown;
   }
 
   /**
@@ -433,7 +460,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get pendingClose () {
-    return this[PENDING_CLOSE];
+    return hasFlag(this, kStatePendingClose);
   }
 
   /**
@@ -441,7 +468,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get closed () {
-    return this[STATE] === CLOSED;
+    return this[STATE] === kStateClosed;
   }
 
   /**
@@ -449,7 +476,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get opened () {
-    return this[STATE] === OPEN;
+    return this[STATE] === kStateOpen;
   }
 
   /**
@@ -457,7 +484,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get halfOpen () {
-    return this[STATE] === HALF_OPEN;
+    return this[STATE] === kStateHalfOpen;
   }
 
   /**
@@ -498,7 +525,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get enabled () {
-    return this[ENABLED];
+    return hasFlag(this, kStateEnabled);
   }
 
   /**
@@ -506,7 +533,7 @@ class CircuitBreaker extends EventEmitter {
    * @type {Boolean}
    */
   get warmUp () {
-    return this[WARMING_UP];
+    return hasFlag(this, kStateWarmingUp);
   }
 
   /**
@@ -624,7 +651,7 @@ class CircuitBreaker extends EventEmitter {
       this.emit('cacheMiss');
     }
 
-    if (!this[ENABLED]) {
+    if (!hasFlag(this, kStateEnabled)) {
       const result = this.action.apply(context, args);
       return (typeof result.then === 'function')
         ? result
@@ -644,7 +671,7 @@ class CircuitBreaker extends EventEmitter {
       return fallback(this, error, args) ||
         Promise.reject(error);
     }
-    this[PENDING_CLOSE] = false;
+    this[STATE_BITSET] &= ~kStatePendingClose;
 
     let timeout;
     let timeoutError = false;
@@ -797,7 +824,7 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   enable () {
-    this[ENABLED] = true;
+    this[STATE_BITSET] |= kStateEnabled;
     this.status.startListeneningForRotateEvent();
   }
 
@@ -807,7 +834,7 @@ class CircuitBreaker extends EventEmitter {
    * @returns {void}
    */
   disable () {
-    this[ENABLED] = false;
+    this[STATE_BITSET] &= ~kStateEnabled;
     this.status.removeRotateBucketControllerListener();
   }
 }

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -41,7 +41,9 @@ class Semaphore {
       return false;
     }
 
-    return this.take() && true;
+    --this[kSemaphoreCounter];
+
+    return true;
   }
 }
 

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -13,28 +13,18 @@ class Semaphore {
     return this[kSemaphoreCounter];
   }
 
-  take (timeout) {
+  take () {
     if (this[kSemaphoreCounter] > 0) {
       --this[kSemaphoreCounter];
 
       return Promise.resolve(this.release.bind(this));
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this[kSemaphoreResolvers].push(_ => {
         --this[kSemaphoreCounter];
         resolve(this.release.bind(this));
       });
-
-      if (timeout) {
-        // TODO: Clean this timeout
-        setTimeout(_ => {
-          this[kSemaphoreResolvers].shift();
-          const err = new Error(`Timed out after ${timeout}ms`);
-          err.code = 'ETIMEDOUT';
-          reject(err);
-        }, timeout);
-      }
     });
   }
 

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -1,37 +1,35 @@
 'use strict';
 
-module.exports = exports = semaphore;
+const kSemaphoreCounter = Symbol('kSemaphoreCounter');
+const kSemaphoreResolvers = Symbol('kSemaphoreResolvers');
 
-function semaphore (count) {
-  const resolvers = [];
-  let counter = count;
+class Semaphore {
+  constructor (count) {
+    this[kSemaphoreCounter] = count;
+    this[kSemaphoreResolvers] = [];
+  }
 
-  const sem = {
-    take,
-    release,
-    test
-  };
+  get count () {
+    return this[kSemaphoreCounter];
+  }
 
-  Object.defineProperty(sem, 'count', {
-    get: _ => counter,
-    enumerable: true
-  });
+  take (timeout) {
+    if (this[kSemaphoreCounter] > 0) {
+      --this[kSemaphoreCounter];
 
-  return sem;
-
-  function take (timeout) {
-    if (counter > 0) {
-      --counter;
-      return Promise.resolve(release);
+      return Promise.resolve(this.release.bind(this));
     }
+
     return new Promise((resolve, reject) => {
-      resolvers.push(_ => {
-        --counter;
-        resolve(release);
+      this[kSemaphoreResolvers].push(_ => {
+        --this[kSemaphoreCounter];
+        resolve(this.release.bind(this));
       });
+
       if (timeout) {
+        // TODO: Clean this timeout
         setTimeout(_ => {
-          resolvers.shift();
+          this[kSemaphoreResolvers].shift();
           const err = new Error(`Timed out after ${timeout}ms`);
           err.code = 'ETIMEDOUT';
           reject(err);
@@ -40,15 +38,25 @@ function semaphore (count) {
     });
   }
 
-  function release () {
-    counter++;
-    if (resolvers.length > 0) {
-      resolvers.shift()();
+  release () {
+    this[kSemaphoreCounter]++;
+
+    if (this[kSemaphoreResolvers].length > 0) {
+      this[kSemaphoreResolvers].shift()();
     }
   }
 
-  function test () {
-    if (counter < 1) return false;
-    return take() && true;
+  test () {
+    if (this[kSemaphoreCounter] < 1) {
+      return false;
+    }
+
+    return this.take() && true;
   }
 }
+
+function SemaphoreCtor (count) {
+  return new Semaphore(count);
+}
+
+module.exports = exports = SemaphoreCtor;

--- a/lib/status.js
+++ b/lib/status.js
@@ -125,7 +125,7 @@ class Status extends EventEmitter {
 
       if (this.rollingPercentilesEnabled) {
         if (val.latencyTimes) {
-          acc.latencyTimes = acc.latencyTimes.concat(val.latencyTimes);
+          Array.prototype.push.apply(acc.latencyTimes, val.latencyTimes);
         }
       }
       return acc;

--- a/lib/status.js
+++ b/lib/status.js
@@ -10,6 +10,8 @@ const ROTATE_EVENT_NAME = Symbol('rotate-event-name');
 
 const EventEmitter = require('events').EventEmitter;
 
+const bucketKeysForStats = ['failures', 'fallbacks', 'successes', 'rejects', 'fires', 'timeouts', 'cacheHits', 'cacheMisses', 'semaphoreRejections'];
+
 /**
  * Tracks execution status for a given {@link CircuitBreaker}.
  * A Status instance is created for every {@link CircuitBreaker}
@@ -113,12 +115,13 @@ class Status extends EventEmitter {
    */
   get stats () {
     const totals = this[WINDOW].reduce((acc, val) => {
-      if (!val) { return acc; }
-      Object.keys(acc).forEach(key => {
-        if (key !== 'latencyTimes' && key !== 'percentiles') {
-          (acc[key] += val[key] || 0);
-        }
-      });
+      if (!val) {
+        return acc;
+      }
+
+      for (const key of bucketKeysForStats) {
+        acc[key] += val[key] || 0;
+      }
 
       if (this.rollingPercentilesEnabled) {
         if (val.latencyTimes) {

--- a/test/semaphore-test.js
+++ b/test/semaphore-test.js
@@ -69,17 +69,6 @@ test('User code cannot change the lock count', t => {
   t.end();
 });
 
-test('A semaphore can time out waiting for a lock', t => {
-  t.plan(1);
-  const sem = Semaphore(1);
-  sem.take().then(_ => {
-    sem.take(100).catch(e => {
-      t.equals(e.code, 'ETIMEDOUT', 'Semaphore lock acquisition timed out');
-      t.end();
-    });
-  });
-});
-
 test('A user can test semaphore to see if a lock is available', t => {
   t.plan(4);
   const sem = Semaphore(1);


### PR DESCRIPTION
Inspired by https://twitter.com/4Kschool/status/1737218913212170699, I tried to search for performance improvements in this library.

### [perf(circuit): use bitset instead of storing valeus inside circuit](https://github.com/nodeshift/opossum/commit/a7368ee894f7b580ba22b617a77f34af69c50598)

Basically, with this change, I tried to condense and reduce the amount of fields/memory needed to store the same information.

### [perf(circuit): remove amount of listeners](https://github.com/nodeshift/opossum/commit/3d08d756e1d28eedc9c8dee8337740e100519f57)

Instead of incrementing the metrics using listeners, I directly increase the number together when I emit the event.
This can introduce a little bit of maintenance burden but also save some memory and increase a little bit the performance for `.emit` since they didn't need to call a function.

### [perf(semaphore): reduce memory footprint for semaphore](https://github.com/nodeshift/opossum/commit/a3a09b0344214cf3248940d7f2301ca5485ca087)

With this rewrite, I reduce the amount of memory needed and this also improves the instantation time of this class.

### [refactor(semaphore): removed unused timeout](https://github.com/nodeshift/opossum/commit/545954ff56f15d8ef77c47e83047fc91b01e5548)

Was not used by this library, so I removed it, let me know if you plan something with this feature and I can revert this commit.

### [perf(circuit): avoid cloning args](https://github.com/nodeshift/opossum/commit/f4b0f626a1c607063b672bf2ccd60fe436470ce6)

Now we have a specialized function that receives the array and we don't need anymore to shallow-clone the args twice.

### [perf(circuit): avoid calling errorFilter when not needed](https://github.com/nodeshift/opossum/commit/b0d98357dbc81c0f1aee5a524685f0c28a2162d9)

Just a minor perf improvement, avoid calling a function that we know the result.

### [perf(circuit): avoid args cloning on fallback fn](https://github.com/nodeshift/opossum/commit/caeac033f525f54a1cecef7bc285f6e3920fb694)

This is a little bit more controversial, I didn't see any reason to avoid modifying the `args` array, so this can save a little bit of memory by avoiding this shallow-clone.

### [perf(status): avoid creating array unecessary for bucket keys](https://github.com/nodeshift/opossum/commit/ef19b9c183873aa6164c1e197b48670c35d805be)

Trying to reduce the amount of memory allocated by caching the keys instead of capturing those keys every time.

### [perf(status): prefer modify original array instead concat old arrays](https://github.com/nodeshift/opossum/commit/b5c63a0f37173f0ee7006a0aca9d77d642dd4f4b)

There's no reason to avoid modifying that array since it was created during `.reduce`, so this helps the performance a little bit and also saves a little bit of memory.

### [perf(semaphore): avoid promise creation when is not needed](https://github.com/nodeshift/opossum/pull/843/commits/8dd4ab06ac2380705d97336eeb9fff3172ed9a4a)

A simple change that speeds a little bit the `fire` action since we avoid creating an unnecessary promise.

---

In general, I tried to measure the perf improvements and using [bench-node](https://github.com/RafaelGSS/bench-node) I got the following results:

Before:

```
create empty circuit x 197,114 ops/sec +/- 0.07% (7 runs sampled) heap usage=3.40Kb (3.30Kb ... 3.49Kb) min..max=(4.68us ... 5.68us) p75=5.18us p99=5.68us
create circuit x 178,761 ops/sec +/- 0.02% (4 runs sampled) heap usage=3.45Kb (3.38Kb ... 3.59Kb) min..max=(5.48us ... 5.72us) p75=5.58us p99=5.72us
create semaphore x 1,331,163 ops/sec +/- 0.2% (2 runs sampled) heap usage=419B (384B ... 454B) min..max=(606ns ... 809ns) p75=809ns p99=809ns
simple fire x 942,144 ops/sec +/- 0.67% (5 runs sampled) heap usage=151B (33B ... 295B) min..max=(996ns ... 3.30us) p75=1.14us p99=3.30us
failure fire x 210,998 ops/sec +/- 0.07% (5 runs sampled) heap usage=1.12Kb (795B ... 1.64Kb) min..max=(4.09us ... 4.96us) p75=4.74us p99=4.96us

create empty circuit x 189,293 ops/sec +/- 0.21% (8 runs sampled) heap usage=3.43Kb (3.34Kb ... 3.48Kb) min..max=(4.52us ... 8.07us) p75=6.01us p99=8.07us
create circuit x 176,277 ops/sec +/- 0.1% (5 runs sampled) heap usage=3.41Kb (3.35Kb ... 3.44Kb) min..max=(5.20us ... 6.62us) p75=5.61us p99=6.62us
create semaphore x 1,366,766 ops/sec +/- 0.23% (2 runs sampled) heap usage=349B (311B ... 387B) min..max=(584ns ... 806ns) p75=806ns p99=806ns
simple fire x 944,067 ops/sec +/- 0.64% (5 runs sampled) heap usage=131B (58B ... 281B) min..max=(964ns ... 3.18us) p75=1.23us p99=3.18us
failure fire x 203,585 ops/sec +/- 0.02% (4 runs sampled) heap usage=1020B (760B ... 1.64Kb) min..max=(4.75us ... 5.00us) p75=4.98us p99=5.00us

create empty circuit x 190,282 ops/sec +/- 0.05% (6 runs sampled) heap usage=3.42Kb (3.35Kb ... 3.46Kb) min..max=(5.14us ... 5.86us) p75=5.27us p99=5.86us
create circuit x 173,088 ops/sec +/- 0.05% (4 runs sampled) heap usage=3.42Kb (3.41Kb ... 3.44Kb) min..max=(5.36us ... 5.96us) p75=5.95us p99=5.96us
create semaphore x 1,202,554 ops/sec +/- 0.18% (2 runs sampled) heap usage=409B (375B ... 443B) min..max=(735ns ... 953ns) p75=953ns p99=953ns
simple fire x 957,888 ops/sec +/- 0.5% (5 runs sampled) heap usage=167B (37B ... 447B) min..max=(983ns ... 2.53us) p75=1.14us p99=2.53us
failure fire x 204,377 ops/sec +/- 0.03% (4 runs sampled) heap usage=1.01Kb (792B ... 1.64Kb) min..max=(4.64us ... 4.98us) p75=4.89us p99=4.98us
```

After:

```
create empty circuit x 253,026 ops/sec +/- 0.14% (7 runs sampled) heap usage=3.04Kb (3.03Kb ... 3.06Kb) min..max=(3.60us ... 5.25us) p75=4.36us p99=5.25us
create circuit x 234,540 ops/sec +/- 0.08% (3 runs sampled) heap usage=3.05Kb (3.04Kb ... 3.06Kb) min..max=(3.93us ... 4.59us) p75=4.59us p99=4.59us
create semaphore x 431,598,754 ops/sec +/- 1.25% (2 runs sampled) heap usage=42B (3B ... 81B) min..max=(1.47ns ... 24.27ns) p75=24.27ns p99=24.27ns
simple fire x 1,076,134 ops/sec +/- 0.66% (4 runs sampled) heap usage=176B (45B ... 472B) min..max=(880ns ... 2.74us) p75=982ns p99=2.74us
failure fire x 216,585 ops/sec +/- 0.01% (3 runs sampled) heap usage=1.04Kb (802B ... 1.56Kb) min..max=(4.59us ... 4.64us) p75=4.64us p99=4.64us

create empty circuit x 262,022 ops/sec +/- 0.1% (8 runs sampled) heap usage=3.05Kb (3.02Kb ... 3.08Kb) min..max=(3.60us ... 4.72us) p75=4.04us p99=4.72us
create circuit x 230,788 ops/sec +/- 0.02% (4 runs sampled) heap usage=3.07Kb (3.05Kb ... 3.10Kb) min..max=(4.21us ... 4.46us) p75=4.38us p99=4.46us
create semaphore x 302,207,559 ops/sec +/- 1.25% (2 runs sampled) heap usage=41B (3B ... 78B) min..max=(1.93ns ... 31.10ns) p75=31.10ns p99=31.10ns
simple fire x 919,432 ops/sec +/- 0.53% (4 runs sampled) heap usage=212B (103B ... 433B) min..max=(965ns ... 2.62us) p75=1.22us p99=2.62us
failure fire x 211,607 ops/sec +/- 0.08% (4 runs sampled) heap usage=991B (778B ... 1.56Kb) min..max=(4.04us ... 4.97us) p75=4.70us p99=4.97us

create empty circuit x 267,593 ops/sec +/- 0.14% (7 runs sampled) heap usage=3.04Kb (3.02Kb ... 3.06Kb) min..max=(3.36us ... 4.96us) p75=4.14us p99=4.96us
create circuit x 230,268 ops/sec +/- 0.05% (4 runs sampled) heap usage=3.05Kb (3.03Kb ... 3.07Kb) min..max=(4.08us ... 4.66us) p75=4.42us p99=4.66us
create semaphore x 461,537,772 ops/sec +/- 1.28% (2 runs sampled) heap usage=50B (3B ... 96B) min..max=(1.32ns ... 25.79ns) p75=25.79ns p99=25.79ns
simple fire x 966,567 ops/sec +/- 0.6% (3 runs sampled) heap usage=224B (84B ... 390B) min..max=(975ns ... 2.60us) p75=2.60us p99=2.60us
failure fire x 209,872 ops/sec +/- 0.05% (4 runs sampled) heap usage=986B (747B ... 1.56Kb) min..max=(4.57us ... 5.09us) p75=4.73us p99=5.09us
```

<details>
<summary>benchmark code</summary>

```js
const CircuitBreaker = require('../index');
const Semaphore = require('../lib/semaphore');
const { Suite, MemoryEnricher } = require('bench-node');

async function asyncFunctionThatCouldFail (x, y) {
}

const breaker = new CircuitBreaker(asyncFunctionThatCouldFail, {
  timeout: 3000, // If our function takes longer than 3 seconds, trigger a failure
  errorThresholdPercentage: 50, // When 50% of requests fail, trip the circuit
  resetTimeout: 30000, // After 30 seconds, try again.
});


const failureBreaker = new CircuitBreaker(async (r) => {
  throw new Error('err');
}, {
  timeout: 3000, // If our function takes longer than 3 seconds, trigger a failure
  errorThresholdPercentage: 50, // When 50% of requests fail, trip the circuit
  resetTimeout: 30000, // After 30 seconds, try again.
});

const benchOptions = {
  maxTime: 2,
  minTime: 0.2
};

const suite = new Suite()
  .add('create empty circuit', () => new CircuitBreaker(asyncFunctionThatCouldFail), benchOptions)
  .add('create circuit', () => new CircuitBreaker(asyncFunctionThatCouldFail, {
    timeout: 3000, // If our function takes longer than 3 seconds, trigger a failure
    errorThresholdPercentage: 50, // When 50% of requests fail, trip the circuit
    resetTimeout: 30000, // After 30 seconds, try again.
  }), benchOptions)
  .add('create semaphore', () => new Semaphore(2))
  .add('simple fire', async () => await breaker.fire(1, 2), benchOptions)
  .add('failure fire', async () => {
    try {
      await failureBreaker.fire(1);
    } catch (e) {

    }
  }, benchOptions)
  .run({
    enrichers: [
      MemoryEnricher,
    ]
  });
```
</details>

I also tried to measure the overhead of simple fire using the following code:

> hyperfine --warmup 3 'node perf-fire.cjs'

```
const CircuitBreaker = require('../index');

async function asyncFunctionThatCouldFail (x, y) {
}

const breaker = new CircuitBreaker(asyncFunctionThatCouldFail, {
  timeout: 3000, // If our function takes longer than 3 seconds, trigger a failure
  errorThresholdPercentage: 50, // When 50% of requests fail, trip the circuit
  resetTimeout: 30000, // After 30 seconds, try again.
});

(async () => {
  for (let i = 0; i < 1e6; i++) {
    await breaker.fire();
  }
})();
```

The output using `hyperfine` is:

Before:

```
Benchmark 1: node perf-fire.cjs                                                                                                            
  Time (mean ± σ):     915.4 ms ±  35.9 ms    [User: 936.0 ms, System: 49.4 ms]                                                            
  Range (min … max):   861.6 ms … 983.8 ms    10 runs                                                                                      
```

After:

```
Benchmark 1: node perf-fire.cjs
  Time (mean ± σ):     771.1 ms ±  10.2 ms    [User: 788.3 ms, System: 52.5 ms]
  Range (min … max):   748.0 ms … 783.7 ms    10 runs
```
