### PR TITLE
chore: add support for nodejs 22

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [16.x, 18.x, 20.x, 21.x, 22.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rate-limiting"
   ],
   "engines": {
-    "node": "^21 || ^20 || ^18 || ^16"
+    "node": "^22 || ^21 || ^20 || ^18 || ^16"
   },
   "support": true
 }


### PR DESCRIPTION
Node.js 22 is released and testing opossum with it works fine for me in automated tests and real project usage. 

Therefore this PR to add v22 as supported engine.
