### PR TITLE
feat: renewing the AbortController when the circuit enters the 'halfClose' or 'close' state

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -107,6 +107,11 @@ Please use options.errorThresholdPercentage`;
  * This option allows you to provide an EventEmitter that rotates the buckets
  * so you can have one global timer in your app. Make sure that you are
  * emitting a 'rotate' event from this EventEmitter
+ * @param {boolean} options.autoRenewAbortController Automatically recreates
+ * the instance of AbortController whenever the circuit transitions to
+ * 'halfOpen' or 'closed' state. This ensures that new requests are not
+ * impacted by previous signals that were triggered when the circuit was 'open'.
+ * Default: false
  *
  *
  * @fires CircuitBreaker#halfOpen
@@ -191,6 +196,10 @@ class CircuitBreaker extends EventEmitter {
       throw new TypeError(
         'No action provided. Cannot construct a CircuitBreaker without an invocable action.'
       );
+    }
+
+    if (options.autoRenewAbortController && !options.abortController) {
+      options.abortController = new AbortController();
     }
 
     if (options.abortController && typeof options.abortController.abort !== 'function') {
@@ -295,6 +304,9 @@ class CircuitBreaker extends EventEmitter {
     function _halfOpen (circuit) {
       circuit[STATE] = HALF_OPEN;
       circuit[PENDING_CLOSE] = true;
+      if (circuit.options.autoRenewAbortController) {
+        circuit.options.abortController = new AbortController();
+      }
       /**
        * Emitted after `options.resetTimeout` has elapsed, allowing for
        * a single attempt to call the service again. If that attempt is
@@ -347,6 +359,13 @@ class CircuitBreaker extends EventEmitter {
       }
       this[STATE] = CLOSED;
       this[PENDING_CLOSE] = false;
+      if (
+        this.options.autoRenewAbortController &&
+          this.options.abortController &&
+          this.options.abortController.signal.aborted
+      ) {
+        this.options.abortController = new AbortController();
+      }
       /**
        * Emitted when the breaker is reset allowing the action to execute again
        * @event CircuitBreaker#close
@@ -809,6 +828,31 @@ class CircuitBreaker extends EventEmitter {
   disable () {
     this[ENABLED] = false;
     this.status.removeRotateBucketControllerListener();
+  }
+
+  /**
+   * Retrieves the current AbortSignal from the abortController, if available.
+   * This signal can be used to monitor ongoing requests.
+   * @returns {AbortSignal|undefined} The AbortSignal if present,
+   * otherwise undefined.
+   */
+  getSignal () {
+    if (this.options.abortController && this.options.abortController.signal) {
+      return this.options.abortController.signal;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Retrieves the current AbortController instance.
+   * This controller can be used to manually abort ongoing requests or create
+   * a new signal.
+   * @returns {AbortController|undefined} The AbortController if present,
+   * otherwise undefined.
+   */
+  getAbortController () {
+    return this.options.abortController;
   }
 }
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -304,9 +304,7 @@ class CircuitBreaker extends EventEmitter {
     function _halfOpen (circuit) {
       circuit[STATE] = HALF_OPEN;
       circuit[PENDING_CLOSE] = true;
-      if (circuit.options.autoRenewAbortController) {
-        circuit.options.abortController = new AbortController();
-      }
+      circuit._renewAbortControllerIfNeeded();
       /**
        * Emitted after `options.resetTimeout` has elapsed, allowing for
        * a single attempt to call the service again. If that attempt is
@@ -348,6 +346,21 @@ class CircuitBreaker extends EventEmitter {
   }
 
   /**
+   * Renews the abort controller if needed
+   * @private
+   * @returns {void}
+   */
+  _renewAbortControllerIfNeeded () {
+    if (
+      this.options.autoRenewAbortController &&
+        this.options.abortController &&
+        this.options.abortController.signal.aborted
+    ) {
+      this.options.abortController = new AbortController();
+    }
+  }
+
+  /**
    * Closes the breaker, allowing the action to execute again
    * @fires CircuitBreaker#close
    * @returns {void}
@@ -359,13 +372,7 @@ class CircuitBreaker extends EventEmitter {
       }
       this[STATE] = CLOSED;
       this[PENDING_CLOSE] = false;
-      if (
-        this.options.autoRenewAbortController &&
-          this.options.abortController &&
-          this.options.abortController.signal.aborted
-      ) {
-        this.options.abortController = new AbortController();
-      }
+      this._renewAbortControllerIfNeeded();
       /**
        * Emitted when the breaker is reset allowing the action to execute again
        * @event CircuitBreaker#close


### PR DESCRIPTION
Introducing a new option to the CircuitBreaker: `autoRenewAbortController`. When enabled, this flag automatically recreates the AbortController whenever the CircuitBreaker state transitions to 'halfOpen' or 'closed'. This ensures the controller is reset and ready for reuse in subsequent state changes.

Closes #861