### PR TITLE
Bugfix for 8.20.0

### DIFF
--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -619,6 +619,13 @@ class CircuitBreaker extends EventEmitter {
 
     const args = rest.slice();
 
+    /**
+     * Emitted when the circuit breaker action is executed
+     * @event CircuitBreaker#fire
+     * @type {any} the arguments passed to the fired function
+     */
+    this.emit('fire', args);
+
     // Protection, caches and coalesce disabled.
     if (!this[ENABLED]) {
       const result = this.action.apply(context, args);
@@ -627,19 +634,11 @@ class CircuitBreaker extends EventEmitter {
         : Promise.resolve(result);
     }
 
-    // Need to create variable here to prevent extra calls if cache is disabled
-    let cacheKey = '';
-
-    /**
-     * Emitted when the circuit breaker action is executed
-     * @event CircuitBreaker#fire
-     * @type {any} the arguments passed to the fired function
-     */
-    this.emit('fire', args);
+    // Generate cachekey only when cache and/or coalesce is enabled.
+    const cacheKey = this.options.cache || this.options.coalesce ? this.options.cacheGetKey.apply(this, rest) : '';
 
     // If cache is enabled, check if we have a cached value
     if (this.options.cache) {
-      cacheKey = this.options.cacheGetKey.apply(this, rest);
       const cached = this.options.cacheTransport.get(cacheKey);
       if (cached) {
         /**


### PR DESCRIPTION
Bugfix: coalesce re-used empty cachekey when cache was not used.
Bugfix: emit fire when circuitbreaker is disabled.