### PR TITLE
feature: Coalesce reset options, reset coalesce based on result. (error, success, timeout)

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -45,6 +45,15 @@ class MemoryCache {
   }
 
   /**
+   * Delete cache key
+   * @param {string} key Cache key
+   * @return {void}
+   */
+  delete (key) {
+    this.cache.delete(key);
+  }
+
+  /**
    * Clear cache
    * @returns {void}
    */

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,7 +6,7 @@
 class MemoryCache {
   constructor (maxEntries) {
     this.cache = new Map();
-    this.maxEntries = maxEntries ?? 2 ^ 24 - 1; // Max size for Map is 2 ^ 24.
+    this.maxEntries = maxEntries ?? 2 ** 24 - 1; // Max size for Map is 2 ^ 24.
   }
 
   /**

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -1007,7 +1007,7 @@ function resetCoalesce (circuit, cacheKey, event) {
  * @returns {void}
  */
   if (!event || circuit.options.coalesceResetOn.includes(event)) {
-    circuit.options.coalesceCache.delete(cacheKey);
+    circuit.options.coalesceCache?.delete(cacheKey);
   }
 }
 

--- a/lib/circuit.js
+++ b/lib/circuit.js
@@ -111,6 +111,8 @@ Please use options.errorThresholdPercentage`;
  * in milliseconds. Set 0 for infinity cache. Default: same as options.timeout
  * @param {Number} options.coalesceSize the max amount of entries in the
  * coalescing cache. Default: max size of JS map (2^24).
+ * @param {string[]} options.coalesceResetOn when to reset the coalesce cache.
+ * Options: `error`, `success`, `timeout`. Default: not set, reset using TTL.
  * @param {AbortController} options.abortController this allows Opossum to
  * signal upon timeout and properly abort your on going requests instead of
  * leaving it in the background
@@ -193,6 +195,7 @@ class CircuitBreaker extends EventEmitter {
     this.options.rotateBucketController = options.rotateBucketController;
     this.options.coalesce = !!options.coalesce;
     this.options.coalesceTTL = options.coalesceTTL ?? this.options.timeout;
+    this.options.coalesceResetOn = options.coalesceResetOn?.filter(o => ['error', 'success', 'timeout'].includes(o)) || [];
 
     // Set default cache transport if not provided
     if (this.options.cache) {
@@ -743,6 +746,8 @@ class CircuitBreaker extends EventEmitter {
                */
               this.emit('timeout', error, latency, args);
               handleError(error, this, timeout, args, latency, resolve, reject);
+              resetCoalesce(this, cacheKey, 'timeout');
+
               if (this.options.abortController) {
                 this.options.abortController.abort();
               }
@@ -764,6 +769,7 @@ class CircuitBreaker extends EventEmitter {
                * @type {any} the return value from the circuit
                */
               this.emit('success', result, (Date.now() - latencyStartTime));
+              resetCoalesce(this, cacheKey, 'success');
               this.semaphore.release();
               resolve(result);
               if (this.options.cache) {
@@ -783,12 +789,14 @@ class CircuitBreaker extends EventEmitter {
                 const latencyEndTime = Date.now() - latencyStartTime;
                 handleError(
                   error, this, timeout, args, latencyEndTime, resolve, reject);
+                resetCoalesce(this, cacheKey, 'error');
               }
             });
         } catch (error) {
           this.semaphore.release();
           const latency = Date.now() - latencyStartTime;
           handleError(error, this, timeout, args, latency, resolve, reject);
+          resetCoalesce(this, cacheKey, 'error');
         }
       } else {
         const latency = Date.now() - latencyStartTime;
@@ -801,6 +809,7 @@ class CircuitBreaker extends EventEmitter {
          */
         this.emit('semaphoreLocked', err, latency);
         handleError(err, this, timeout, args, latency, resolve, reject);
+        resetCoalesce(this, cacheKey);
       }
     });
 
@@ -825,6 +834,10 @@ class CircuitBreaker extends EventEmitter {
   clearCache () {
     if (this.options.cache) {
       this.options.cacheTransport.flush();
+    }
+
+    if (this.options.coalesceCache) {
+      this.options.coalesceCache.flush();
     }
   }
 
@@ -940,6 +953,7 @@ function handleError (error, circuit, timeout, args, latency, resolve, reject) {
     const fb = fallback(circuit, error, args);
     if (fb) return resolve(fb);
   }
+
   // In all other cases, reject
   reject(error);
 }
@@ -980,6 +994,20 @@ function fail (circuit, err, args, latency) {
   if (errorRate > circuit.options.errorThresholdPercentage ||
     circuit.halfOpen) {
     circuit.open();
+  }
+}
+
+function resetCoalesce (circuit, cacheKey, event) {
+/**
+ * Reset coalesce cache for this cacheKey, depending on
+ * options.coalesceResetOn set.
+ * @param {@link CircuitBreaker} circuit what circuit is to be cleared
+ * @param {string} cacheKey cache key to clear.
+ * @param {string} event optional, can be `error`, `success`, `timeout`
+ * @returns {void}
+ */
+  if (!event || circuit.options.coalesceResetOn.includes(event)) {
+    circuit.options.coalesceCache.delete(cacheKey);
   }
 }
 


### PR DESCRIPTION
After implementing coalescing in our software, we noticed it would be handy to better finetune coalescion behavior. 

So added the option to reset coalescion cache at different stages: error, success, timeout. This can be used as sometimes you'd like to retry after an error/timeout, or would like to limit cache TTL without limiting coalescion TTL (e.g. a slow action to fetch data you do want to execute as often as possible but never twice at the same time).

